### PR TITLE
"command" invoked in limited codition

### DIFF
--- a/src/Exception/UnmatchedQuery.php
+++ b/src/Exception/UnmatchedQuery.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\QueryRepository\Exception;
+
+class UnmatchedQuery extends \InvalidArgumentException
+{
+}


### PR DESCRIPTION
RefreshSameCommand invoked only PUT, PATCH, or DELETE.
Also, ignore if the command query is not contained in onGet query.
