### PR TITLE
@Cacheable cache type

### DIFF
--- a/src-annotation/Cacheable.php
+++ b/src-annotation/Cacheable.php
@@ -27,4 +27,10 @@ final class Cacheable
      * @var bool
      */
     public $update = true;
+
+    /**
+     * @var string
+     * @Enum({"value", "view"})
+     */
+    public $type = 'value';
 }

--- a/src/CacheInterceptor.php
+++ b/src/CacheInterceptor.php
@@ -53,14 +53,13 @@ class CacheInterceptor implements MethodInterceptor
         /* @var $resourceObject ResourceObject */
         $stored = $this->repository->get($resourceObject->uri);
         if ($stored) {
-            list($resourceObject->code, $resourceObject->headers, $resourceObject->body) = $stored;
+            list($resourceObject->code, $resourceObject->headers, $resourceObject->body, $resourceObject->view) = $stored;
 
             return $resourceObject;
         }
         /* @var $cacheable Cacheable */
         try {
             $resourceObject = $invocation->proceed();
-            (string) $resourceObject;
             $this->setEtag->__invoke($resourceObject);
             $this->repository->put($resourceObject);
         } catch (\Exception $e) {

--- a/src/EtagSetter.php
+++ b/src/EtagSetter.php
@@ -14,10 +14,10 @@ class EtagSetter implements EtagSetterInterface
     {
         $time = ! is_null($time) ?: time();
 
-        if ($resourceObject->code !== 200 || ! $resourceObject->view) {
+        if ($resourceObject->code !== 200) {
             return;
         }
-        $resourceObject->headers['ETag'] = (string) crc32($resourceObject->view);
+        $resourceObject->headers['ETag'] = (string) crc32(serialize($resourceObject->view) . serialize($resourceObject->body));
         $resourceObject->headers['Last-Modified'] = gmdate("D, d M Y H:i:s", $time) . ' GMT';
     }
 }

--- a/src/MobileEtagSetter.php
+++ b/src/MobileEtagSetter.php
@@ -13,7 +13,7 @@ class MobileEtagSetter implements EtagSetterInterface
     public function __invoke(ResourceObject $resourceObject, $time = null)
     {
         // etag]
-        $resourceObject->headers['ETag'] = (string) crc32($this->getDevice() . (string) $resourceObject);
+        $resourceObject->headers['ETag'] = (string) crc32($this->getDevice() . serialize($resourceObject->view) . serialize($resourceObject->body));
         // time
         $time = ! is_null($time) ?: time();
         $resourceObject->headers['Last-Modified'] = gmdate("D, d M Y H:i:s", $time) . ' GMT';

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -70,7 +70,9 @@ class QueryRepository implements QueryRepositoryInterface
         /* @var $cacheable Cacheable */
         $cacheable = $this->reader->getClassAnnotation(new \ReflectionClass($ro), Cacheable::class);
         $lifeTime = $this->getExpiryTime($cacheable);
-
+        if ($cacheable instanceof Cacheable && $cacheable->type === 'view') {
+            (string) $ro;
+        }
         return $this->kvs->save((string) $ro->uri, $ro, $lifeTime);
     }
 

--- a/tests/CacheTypeTest.php
+++ b/tests/CacheTypeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace BEAR\QueryRepository;
+
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceClientFactory;
+use BEAR\Resource\ResourceFactory;
+use BEAR\Resource\ResourceInterface;
+use Ray\Di\Injector;
+
+class CacheTypeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ResourceInterface
+     */
+    private $resource;
+
+    public function setUp()
+    {
+        $this->resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld'))))->getInstance(ResourceInterface::class);
+
+        parent::setUp();
+    }
+
+    public function testValue()
+    {
+        $ro = $this->resource->get->uri('app://self/value')->withQuery(['id' => 1])->eager->request();
+        // put
+        $expect = 'Last-Modified';
+        $this->assertArrayHasKey($expect, $ro->headers);
+        $time = $ro['time'];
+        // get
+        $ro = $this->resource->get->uri('app://self/value')->withQuery(['id' => 1])->eager->request();
+        $this->assertArrayHasKey($expect, $ro->headers);
+        $expect = $time;
+        $this->assertSame($expect, $ro['time']);
+        $this->assertNull($ro->view);
+    }
+
+    public function testView()
+    {
+        $ro = $this->resource->get->uri('app://self/view')->withQuery(['id' => 1])->eager->request();
+        // put
+        $expect = 'Last-Modified';
+        $this->assertArrayHasKey($expect, $ro->headers);
+        $time = $ro['time'];
+        // get
+        $ro = $this->resource->get->uri('app://self/view')->withQuery(['id' => 1])->eager->request();
+        $this->assertArrayHasKey($expect, $ro->headers);
+        $expect = $time;
+        $this->assertSame($expect, $ro['time']);
+        $this->assertSame('view', $ro->view);
+    }
+}

--- a/tests/CacheTypeTest.php
+++ b/tests/CacheTypeTest.php
@@ -18,37 +18,48 @@ class CacheTypeTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld'))))->getInstance(ResourceInterface::class);
-
         parent::setUp();
+    }
+
+    public function requestDobule($uri)
+    {
+        $ro = $this->resource->get->uri($uri)->eager->request();
+        // put
+        $expect = 'Last-Modified';
+        $this->assertArrayHasKey($expect, $ro->headers);
+        $time = $ro['time'];
+        // get
+        $ro = $this->resource->get->uri($uri)->eager->request();
+        $this->assertArrayHasKey($expect, $ro->headers);
+        $expect = $time;
+        $this->assertSame($expect, $ro['time']);
+
+        return $ro;
     }
 
     public function testValue()
     {
-        $ro = $this->resource->get->uri('app://self/value')->withQuery(['id' => 1])->eager->request();
+        $uri = 'app://self/value';
         // put
-        $expect = 'Last-Modified';
-        $this->assertArrayHasKey($expect, $ro->headers);
+        $ro = $this->resource->get->uri($uri)->eager->request();
+        (string) $ro;
         $time = $ro['time'];
-        // get
-        $ro = $this->resource->get->uri('app://self/value')->withQuery(['id' => 1])->eager->request();
-        $this->assertArrayHasKey($expect, $ro->headers);
-        $expect = $time;
-        $this->assertSame($expect, $ro['time']);
-        $this->assertNull($ro->view);
+        $this->assertSame('1' . $time, $ro->view);
+        $ro = $this->resource->get->uri($uri)->eager->request();
+        (string) $ro;
+        $this->assertSame('2' . $time, $ro->view);
     }
 
     public function testView()
     {
-        $ro = $this->resource->get->uri('app://self/view')->withQuery(['id' => 1])->eager->request();
+        $uri = 'app://self/view';
         // put
-        $expect = 'Last-Modified';
-        $this->assertArrayHasKey($expect, $ro->headers);
+        $ro = $this->resource->get->uri($uri)->eager->request();
+        (string) $ro;
         $time = $ro['time'];
-        // get
-        $ro = $this->resource->get->uri('app://self/view')->withQuery(['id' => 1])->eager->request();
-        $this->assertArrayHasKey($expect, $ro->headers);
-        $expect = $time;
-        $this->assertSame($expect, $ro['time']);
-        $this->assertSame('view', $ro->view);
+        $this->assertSame('1' . $time, $ro->view);
+        $ro = $this->resource->get->uri($uri)->eager->request();
+        (string) $ro;
+        $this->assertSame('1' . $time, $ro->view);
     }
 }

--- a/tests/Fake/fake-app/src/Resource/App/Value.php
+++ b/tests/Fake/fake-app/src/Resource/App/Value.php
@@ -10,17 +10,21 @@ use BEAR\Resource\ResourceObject;
  */
 class Value extends ResourceObject
 {
+    static $i = 1;
+
     public function __toString()
     {
-        $this->view = 'value';
+        if ($this->view) {
+            return $this->view;
+        }
+        $this->view = (string) self::$i++ . $this['time'];
 
         return $this->view;
     }
 
-    public function onGet($id)
+    public function onGet()
     {
-        $this->body['id'] = $id;
-        $this['time'] = microtime(true);
+        $this['time'] = (string) microtime(true);
 
         return $this;
     }

--- a/tests/Fake/fake-app/src/Resource/App/Value.php
+++ b/tests/Fake/fake-app/src/Resource/App/Value.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable(type="value")
+ */
+class Value extends ResourceObject
+{
+    public function __toString()
+    {
+        $this->view = 'value';
+
+        return $this->view;
+    }
+
+    public function onGet($id)
+    {
+        $this->body['id'] = $id;
+        $this['time'] = microtime(true);
+
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/App/View.php
+++ b/tests/Fake/fake-app/src/Resource/App/View.php
@@ -10,17 +10,21 @@ use BEAR\Resource\ResourceObject;
  */
 class View extends ResourceObject
 {
+    static $i = 1;
+
     public function __toString()
     {
-        $this->view = 'view';
+        if ($this->view) {
+            return $this->view;
+        }
+        $this->view = (string) self::$i++ . $this['time'];
 
         return $this->view;
     }
 
-    public function onGet($id)
+    public function onGet()
     {
-        $this->body['id'] = $id;
-        $this['time'] = microtime(true);
+        $this['time'] = (string) microtime(true);
 
         return $this;
     }

--- a/tests/Fake/fake-app/src/Resource/App/View.php
+++ b/tests/Fake/fake-app/src/Resource/App/View.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable(type="view")
+ */
+class View extends ResourceObject
+{
+    public function __toString()
+    {
+        $this->view = 'view';
+
+        return $this->view;
+    }
+
+    public function onGet($id)
+    {
+        $this->body['id'] = $id;
+        $this['time'] = microtime(true);
+
+        return $this;
+    }
+}


### PR DESCRIPTION
`@Cacheable` have a type either `value`  or `view`. The default is `value`

A **value cacheable** resource only cache resource value (code, headers body). This is more flexible it can have dynamic template.  

```
/**
 * @Cacheable(type="value")
 */
```

A **view cacheable** resource cache resource view as well as resource value (code, headers body). This has better performance when template is not dynamic.

```
/**
 * @Cacheable(type="view")
 */
```

A body of  **Value cacheable** resource can have a embedded resource request. The resource request will be cached. Not a resource request result.

You can embed resource request with @Embed annotation.

```
    /**
     * @Embed(rel="uid", src="app://self/user/uid")
     */
```

or setting resource request.

```
$this['weekday'] = $this->resource
            ->get
            ->uri('app://self/weekday')
            ->withQuery(['year' => $year, 'month' => $month, 'day' => $day])
            ->request();
```

Note: Do NOT use `eager` when you want to embed "request" nor a request result.
