### PR TITLE
Set etag after cache made successfully

### DIFF
--- a/src/CacheInterceptor.php
+++ b/src/CacheInterceptor.php
@@ -56,8 +56,8 @@ class CacheInterceptor implements MethodInterceptor
         /* @var $cacheable Cacheable */
         try {
             $resourceObject = $invocation->proceed();
-            $this->setEtag->__invoke($resourceObject);
             $this->repository->put($resourceObject);
+            $this->setEtag->__invoke($resourceObject);
         } catch (\Exception $e) {
             $this->repository->purge($resourceObject->uri);
         }

--- a/src/CacheInterceptor.php
+++ b/src/CacheInterceptor.php
@@ -60,6 +60,7 @@ class CacheInterceptor implements MethodInterceptor
             $this->setEtag->__invoke($resourceObject);
         } catch (\Exception $e) {
             $this->repository->purge($resourceObject->uri);
+            error_log($e);
         }
 
         return $resourceObject;


### PR DESCRIPTION
Devs can notice the cache made failure by not only log but also Etag is not present in unit test.