### PR TITLE
Add CacheVersionModule

### DIFF
--- a/src-annotation/CacheVersion.php
+++ b/src-annotation/CacheVersion.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\RepositoryModule\Annotation;
+use Ray\Di\Di\Qualifier;
+
+/**
+ * @Annotation
+ * @Target("METHOD")
+ * @Qualifier()
+ */
+final class CacheVersion
+{
+    /**
+     * @var string
+     */
+    public $value;
+}

--- a/src-annotation/ExpiryConfig.php
+++ b/src-annotation/ExpiryConfig.php
@@ -5,10 +5,12 @@
  * @license http://opensource.org/licenses/MIT MIT
  */
 namespace BEAR\RepositoryModule\Annotation;
+use Ray\Di\Di\Qualifier;
 
 /**
  * @Annotation
  * @Target("METHOD")
+ * @Qualifier()
  */
 final class ExpiryConfig
 {

--- a/src/CacheVersionModule.php
+++ b/src/CacheVersionModule.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\QueryRepository;
+
+use BEAR\RepositoryModule\Annotation\CacheVersion;
+use Ray\Di\AbstractModule;
+
+class CacheVersionModule extends AbstractModule
+{
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * @param string              $cacheVersion
+     * @param AbstractModule|null $module
+     */
+    public function __construct($cacheVersion, AbstractModule $module = null)
+    {
+        $this->version = $cacheVersion;
+        parent::__construct($module);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->bind()->annotatedWith(CacheVersion::class)->toInstance($this->version);
+    }
+}

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -7,12 +7,13 @@
 namespace BEAR\QueryRepository;
 
 use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\RepositoryModule\Annotation\ExpiryConfig;
+use BEAR\RepositoryModule\Annotation\Storage;
 use BEAR\Resource\AbstractUri;
 use BEAR\Resource\ResourceObject;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
-use Ray\Di\Di\Named;
 
 class QueryRepository implements QueryRepositoryInterface
 {
@@ -44,7 +45,8 @@ class QueryRepository implements QueryRepositoryInterface
      * @param Reader              $reader
      * @param string              $expiry
      *
-     * @Named("kvs=BEAR\RepositoryModule\Annotation\Storage,expiry=BEAR\RepositoryModule\Annotation\ExpiryConfig")
+     * @Storage("kvs")
+     * @ExpiryConfig("expiry")
      */
     public function __construct(
         EtagSetterInterface $setEtag,

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -10,6 +10,7 @@ use BEAR\RepositoryModule\Annotation\Cacheable;
 use BEAR\Resource\AbstractUri;
 use BEAR\Resource\ResourceObject;
 use Doctrine\Common\Annotations\Reader;
+use Doctrine\Common\Cache\Cache;
 use Doctrine\Common\Cache\CacheProvider;
 use Ray\Di\Di\Named;
 
@@ -43,11 +44,11 @@ class QueryRepository implements QueryRepositoryInterface
      * @param Reader              $reader
      * @param string              $expiry
      *
-     * @Named("kvs=BEAR\RepositoryModule\Annotation\Storage, expiry=BEAR\RepositoryModule\Annotation\ExpiryConfig")
+     * @Named("kvs=BEAR\RepositoryModule\Annotation\Storage,expiry=BEAR\RepositoryModule\Annotation\ExpiryConfig")
      */
     public function __construct(
         EtagSetterInterface $setEtag,
-        CacheProvider $kvs,
+        Cache $kvs,
         Reader $reader,
         $expiry
     ) {

--- a/src/QueryRepositoryModule.php
+++ b/src/QueryRepositoryModule.php
@@ -6,6 +6,7 @@
  */
 namespace BEAR\QueryRepository;
 
+use BEAR\RepositoryModule\Annotation\CacheVersion;
 use BEAR\RepositoryModule\Annotation\Commands;
 use BEAR\RepositoryModule\Annotation\ExpiryConfig;
 use BEAR\RepositoryModule\Annotation\Storage;
@@ -47,6 +48,7 @@ class QueryRepositoryModule extends AbstractModule
         $this->bind(Reader::class)->to(AnnotationReader::class)->in(Scope::SINGLETON);
         $this->bind(HttpCacheInterface::class)->to(HttpCache::class);
         $this->bind()->annotatedWith(Commands::class)->toProvider(CommandsProvider::class);
+        $this->bind()->annotatedWith(CacheVersion::class)->toInstance('');
         $this->install(new QueryRepositoryAopModule);
     }
 }

--- a/src/StorageProvider.php
+++ b/src/StorageProvider.php
@@ -6,6 +6,7 @@
  */
 namespace BEAR\QueryRepository;
 
+use BEAR\RepositoryModule\Annotation\CacheVersion;
 use BEAR\RepositoryModule\Annotation\Storage;
 use BEAR\Resource\Annotation\AppName;
 use Doctrine\Common\Cache\CacheProvider;
@@ -24,16 +25,24 @@ class StorageProvider implements ProviderInterface
     private $appName;
 
     /**
+     * @var string
+     */
+    private $version;
+
+    /**
      * @param CacheProvider $kvs
      * @param mixed         $appName
+     * @param mixed         $version
      *
      * @Storage
      * @AppName("appName")
+     * @CacheVersion("version")
      */
-    public function __construct(CacheProvider $kvs, $appName)
+    public function __construct(CacheProvider $kvs, $appName, $version)
     {
         $this->kvs = $kvs;
         $this->appName = $appName;
+        $this->version = (string) $version;
     }
 
     /**
@@ -41,7 +50,7 @@ class StorageProvider implements ProviderInterface
      */
     public function get()
     {
-        $this->kvs->setNamespace($this->appName);
+        $this->kvs->setNamespace($this->appName . $this->version);
 
         return $this->kvs;
     }

--- a/src/StorageProvider.php
+++ b/src/StorageProvider.php
@@ -9,7 +9,6 @@ namespace BEAR\QueryRepository;
 use BEAR\RepositoryModule\Annotation\Storage;
 use BEAR\Resource\Annotation\AppName;
 use Doctrine\Common\Cache\CacheProvider;
-use Ray\Di\Di\Inject;
 use Ray\Di\ProviderInterface;
 
 class StorageProvider implements ProviderInterface
@@ -26,22 +25,14 @@ class StorageProvider implements ProviderInterface
 
     /**
      * @param CacheProvider $kvs
+     * @param mixed         $appName
      *
      * @Storage
+     * @AppName("appName")
      */
-    public function __construct(CacheProvider $kvs)
+    public function __construct(CacheProvider $kvs, $appName)
     {
         $this->kvs = $kvs;
-    }
-
-    /**
-     * @param string $appName
-     *
-     * @Inject
-     * @AppName
-     */
-    public function setAppName($appName)
-    {
         $this->appName = $appName;
     }
 

--- a/tests/CacheVersionModuleTest.php
+++ b/tests/CacheVersionModuleTest.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\QueryRepository;
+
+use BEAR\RepositoryModule\Annotation\Storage;
+use BEAR\Resource\Module\ResourceModule;
+use Doctrine\Common\Cache\Cache;
+use Ray\Di\Injector;
+
+class CacheVersionModuleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNew()
+    {
+        $namespace = 'FakeVendor\HelloWorld';
+        $version = '1';
+        $injector = new Injector(new CacheVersionModule($version, new QueryRepositoryModule(new MobileEtagModule(new ResourceModule($namespace))), $_ENV['TMP_DIR']));
+        $cache = $injector->getInstance(Cache::class, Storage::class);
+        /* @var $cache \Doctrine\Common\Cache\CacheProvider */
+        $ns = $cache->getNamespace();
+        $expected = $namespace . $version;
+        $this->assertSame($expected, $ns);
+    }
+}


### PR DESCRIPTION
In `ProdModule`, You can control cache "Cache Version".

```php
    /**
     * {@inheritdoc}
     */
    protected function configure()
    {
        $version = '1';
        $this->install(new CacheVersionModule($version));
    }
}
```

With this module, You don't need to clear cache in each deployment.