### PR TITLE
Add RFC 7234 Cache-Control 'max-age' header with @Cacheable annotation

### DIFF
--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -66,6 +66,7 @@ class QueryRepository implements QueryRepositoryInterface
         /* @var $cacheable Cacheable */
         $cacheable = $this->getCacheable($ro);
         $lifeTime = $this->getExpiryTime($cacheable);
+        $this->setMaxAge($ro, $lifeTime);
         $body = $this->evaluateBody($ro->body);
         if ($cacheable instanceof Cacheable && $cacheable->type === 'view') {
             if (! $ro->view) {
@@ -171,5 +172,16 @@ class QueryRepository implements QueryRepositoryInterface
         }
 
         return $cacheable->expirySecond ? $cacheable->expirySecond : $this->expiry[$cacheable->expiry];
+    }
+
+    private function setMaxAge(ResourceObject $ro, int $age)
+    {
+        $setMaxAge = \sprintf('max-age=%d', $age);
+        if (isset($ro->headers['Cache-Control'])) {
+            $ro->headers['Cache-Control'] .= ', ' . $setMaxAge;
+
+            return;
+        }
+        $ro->headers['Cache-Control'] = $setMaxAge;
     }
 }

--- a/tests/Fake/fake-app/src/Resource/App/ControlNone.php
+++ b/tests/Fake/fake-app/src/Resource/App/ControlNone.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable(expirySecond=60)
+ */
+class ControlNone extends ResourceObject
+{
+    public function onGet() : ResourceObject
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/App/ControlPublic.php
+++ b/tests/Fake/fake-app/src/Resource/App/ControlPublic.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable(expirySecond=60)
+ */
+class ControlPublic extends ResourceObject
+{
+    public function onGet() : ResourceObject
+    {
+        $this->headers = ['Cache-Control' => 'public'];
+
+        return $this;
+    }
+}

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -21,11 +21,10 @@ class GetInterceptorTest extends TestCase
     public function setUp()
     {
         $this->resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld'))))->getInstance(ResourceInterface::class);
-
         parent::setUp();
     }
 
-    public function testInvoke()
+    public function testLastModifiedHeader()
     {
         $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
         // put
@@ -37,5 +36,19 @@ class GetInterceptorTest extends TestCase
         $this->assertArrayHasKey($expect, $user->headers);
         $expect = $time;
         $this->assertSame($expect, $user['time']);
+    }
+
+    public function testCacheControlHeaderNone()
+    {
+        $user = $this->resource->get->uri('app://self/control-none')->eager->request();
+        $this->assertArrayHasKey('Cache-Control', $user->headers);
+        $this->assertSame('max-age=60', $user->headers['Cache-Control']);
+    }
+
+    public function testCacheControlHeaderPublic()
+    {
+        $user = $this->resource->get->uri('app://self/control-public')->eager->request();
+        $this->assertArrayHasKey('Cache-Control', $user->headers);
+        $this->assertSame('public, max-age=60', $user->headers['Cache-Control']);
     }
 }


### PR DESCRIPTION
> max-age
>
> Indicates that the client is willing to accept a response whose age is no greater than the specified time in seconds. Unless max- stale directive is also included, the client is not willing to accept a stale response.

Support "Cache-Control: max-age"
![image](https://user-images.githubusercontent.com/529021/46527711-ee32f280-c8cc-11e8-8286-555a04add4ab.png)

```php
/**
 * @Cacheable(expirySecond=120)
 */
class ControlNone extends ResourceObject
{
    public function onGet() : ResourceObject
    {
        return $this;
    }
}
```

produces `Cache-Control` header as following.

```
Cache-Control: max-age=120
```

* https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
* https://developers.google.com/speed/docs/insights/LeverageBrowserCaching
* https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching#cache-control
* https://developer.mozilla.org/ja/docs/Web/HTTP/Caching