### PR TITLE
Add `expiry_at` attribute to @Cacheable annotation

### DIFF
--- a/src-annotation/Cacheable.php
+++ b/src-annotation/Cacheable.php
@@ -24,6 +24,11 @@ final class Cacheable
     public $expirySecond;
 
     /**
+     * @var string
+     */
+    public $expiryAt = '';
+
+    /**
      * @var bool
      */
     public $update = true;

--- a/src/Exception/ExpireAtKeyNotExists.php
+++ b/src/Exception/ExpireAtKeyNotExists.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\QueryRepository\Exception;
+
+class ExpireAtKeyNotExists extends \LogicException
+{
+}

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -6,6 +6,7 @@
  */
 namespace BEAR\QueryRepository;
 
+use BEAR\QueryRepository\Exception\ExpireAtKeyNotExists;
 use BEAR\RepositoryModule\Annotation\Cacheable;
 use BEAR\RepositoryModule\Annotation\Storage;
 use BEAR\Resource\AbstractUri;
@@ -13,7 +14,6 @@ use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceObject;
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Cache\Cache;
-use LogicException;
 
 class QueryRepository implements QueryRepositoryInterface
 {
@@ -178,7 +178,7 @@ class QueryRepository implements QueryRepositoryInterface
     {
         if (! isset($ro->body[$cacheable->expiryAt])) {
             $msg = \sprintf('%s::%s', \get_class($ro), $cacheable->expiryAt);
-            throw new LogicException($msg);
+            throw new ExpireAtKeyNotExists($msg);
         }
         $expiryAt = $ro->body[$cacheable->expiryAt];
         $sec = \strtotime($expiryAt) - \time();

--- a/tests/CacheTypeTest.php
+++ b/tests/CacheTypeTest.php
@@ -20,7 +20,7 @@ class CacheTypeTest extends TestCase
 
     public function setUp()
     {
-        $this->resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld'))))->getInstance(ResourceInterface::class);
+        $this->resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld')), $_ENV['TMP_DIR']))->getInstance(ResourceInterface::class);
         parent::setUp();
     }
 

--- a/tests/Fake/fake-app/src/Resource/App/ControlExpiry.php
+++ b/tests/Fake/fake-app/src/Resource/App/ControlExpiry.php
@@ -8,7 +8,6 @@ namespace FakeVendor\HelloWorld\Resource\App;
 
 use BEAR\RepositoryModule\Annotation\Cacheable;
 use BEAR\Resource\ResourceObject;
-use DateTime;
 
 /**
  * @Cacheable(expiryAt="expiry_at")
@@ -19,7 +18,7 @@ class ControlExpiry extends ResourceObject
 
     public function onGet() : ResourceObject
     {
-        $this->body['expiry_at'] = (new DateTime('+30 sec'))->format('Y-m-d H:i:s'); // NOW + 30 sec
+        $this->body['expiry_at'] = (new \DateTime('+30 sec'))->format('Y-m-d H:i:s'); // NOW + 30 sec
 
         return $this;
     }

--- a/tests/Fake/fake-app/src/Resource/App/ControlExpiry.php
+++ b/tests/Fake/fake-app/src/Resource/App/ControlExpiry.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+use DateTime;
+
+/**
+ * @Cacheable(expiryAt="expiry_at")
+ */
+class ControlExpiry extends ResourceObject
+{
+    public $headers = ['Cache-Control' => 'public'];
+
+    public function onGet() : ResourceObject
+    {
+        $this->body['expiry_at'] = (new DateTime('+30 sec'))->format('Y-m-d H:i:s'); // NOW + 30 sec
+
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/App/ControlExpiryError.php
+++ b/tests/Fake/fake-app/src/Resource/App/ControlExpiryError.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable(expiryAt="expiry_at")
+ */
+class ControlExpiryError extends ResourceObject
+{
+    public function onGet() : ResourceObject
+    {
+        return $this;
+    }
+}

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -45,10 +45,10 @@ class GetInterceptorTest extends TestCase
         $this->assertSame('max-age=60', $user->headers['Cache-Control']);
     }
 
-    public function testCacheControlHeaderPublic()
+    public function testCacheControlHeaderExpiry()
     {
-        $user = $this->resource->get->uri('app://self/control-public')->eager->request();
+        $user = $this->resource->get->uri('app://self/control-expiry')->eager->request();
         $this->assertArrayHasKey('Cache-Control', $user->headers);
-        $this->assertSame('public, max-age=60', $user->headers['Cache-Control']);
+        $this->assertSame('public, max-age=30', $user->headers['Cache-Control']);
     }
 }

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -21,7 +21,7 @@ class GetInterceptorTest extends TestCase
 
     public function setUp()
     {
-        $this->resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld'))))->getInstance(ResourceInterface::class);
+        $this->resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld')), $_ENV['TMP_DIR']))->getInstance(ResourceInterface::class);
         parent::setUp();
     }
 

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -6,6 +6,7 @@
  */
 namespace BEAR\QueryRepository;
 
+use BEAR\QueryRepository\Exception\ExpireAtKeyNotExists;
 use BEAR\Resource\Module\ResourceModule;
 use BEAR\Resource\ResourceInterface;
 use PHPUnit\Framework\TestCase;
@@ -50,5 +51,11 @@ class GetInterceptorTest extends TestCase
         $user = $this->resource->get->uri('app://self/control-expiry')->eager->request();
         $this->assertArrayHasKey('Cache-Control', $user->headers);
         $this->assertSame('public, max-age=30', $user->headers['Cache-Control']);
+    }
+
+    public function testCacheControlHeaderExpiryError()
+    {
+        $this->expectException(ExpireAtKeyNotExists::class);
+        $this->resource->get->uri('app://self/control-expiry-error')->eager->request();
     }
 }

--- a/tests/StorageApcModuleTest.php
+++ b/tests/StorageApcModuleTest.php
@@ -16,7 +16,7 @@ class StorageApcModuleTest extends TestCase
 {
     public function testNew()
     {
-        $cache = (new Injector(new StorageApcModule))->getInstance(CacheProvider::class, Storage::class);
+        $cache = (new Injector(new StorageApcModule, $_ENV['TMP_DIR']))->getInstance(CacheProvider::class, Storage::class);
         $this->assertInstanceOf(ApcuCache::class, $cache);
     }
 }

--- a/tests/StorageRedisModuleTest.php
+++ b/tests/StorageRedisModuleTest.php
@@ -18,7 +18,7 @@ class StorageRedisModuleTest extends TestCase
     {
         // @see http://php.net/manual/en/memcached.addservers.php
         $server = 'localhost:6379';
-        $cache = (new Injector(new StorageRedisModule($server)))->getInstance(CacheProvider::class, Storage::class);
+        $cache = (new Injector(new StorageRedisModule($server), $_ENV['TMP_DIR']))->getInstance(CacheProvider::class, Storage::class);
         $this->assertInstanceOf(RedisCache::class, $cache);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,17 +4,7 @@
  *
  * @license http://opensource.org/licenses/MIT MIT
  */
-use Doctrine\Common\Annotations\AnnotationRegistry;
-
-load: {
-    $loader = require \dirname(__DIR__) . '/vendor/autoload.php';
-    AnnotationRegistry::registerLoader([$loader, 'loadClass']);
-}
-
-constants: {
-    $_ENV['TMP_DIR'] = __DIR__ . '/tmp';
-}
-
+$_ENV['TMP_DIR'] = __DIR__ . '/tmp';
 $unlink = function ($path) use (&$unlink) {
     foreach (\glob(\rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . '*') as $file) {
         \is_dir($file) ? $unlink($file) : \unlink($file);


### PR DESCRIPTION
The body key specified with `@Cacheable` 's `expiryAt` attribute specified the expiration date of the resource state (cache). It is used when the expiration date of the resource state is known beforehand.


`@Cacheable`の`expiryAt`アトリビュートで指定したbodyキーがリソース状態（キャッシュ）の有効期限になります。

あらかじめリソース状態の有効期限が分かっているときに使用します。



```php
/**
 * @Cacheable(expiryAt="expiry_at")
 */
class ControlExpiry extends ResourceObject
{
    public $headers = ['Cache-Control' => 'public'];

    public function onGet() : ResourceObject
    {
        $this->body['expiry_at'] =  $expireyDate; // ex) (new \DateTime('+30 sec'))->format('Y-m-d H:i:s'); // NOW + 30 sec
    }
```