### PR TITLE
Refactor, Add HttpCache::transfer() method

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -21,6 +21,11 @@
     </projectFiles>
 
     <issueHandlers>
+        <UndefinedMethod>
+            <errorLevel type="suppress">
+                <file name="src/RefreshSameCommand.php" />
+            </errorLevel>
+        </UndefinedMethod>
         <LessSpecificReturnType errorLevel="info" />
 
         <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->

--- a/src/HttpCache.php
+++ b/src/HttpCache.php
@@ -40,4 +40,17 @@ final class HttpCache implements HttpCacheInterface
 
         return $this->kvs->contains($etagKey) ? true : false;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transfer()
+    {
+        if (PHP_SAPI === 'cli') {
+            echo '304 Not Modified' . PHP_EOL . PHP_EOL;
+
+            return;
+        }
+        \http_response_code(304);
+    }
 }

--- a/src/HttpCache.php
+++ b/src/HttpCache.php
@@ -23,11 +23,7 @@ final class HttpCache implements HttpCacheInterface
      */
     public function isNotModified(array $server) : bool
     {
-        if (! isset($server['HTTP_IF_NONE_MATCH'])) {
-            return false;
-        }
-
-        return $this->storage->hasEtag($server['HTTP_IF_NONE_MATCH']);
+        return isset($server['HTTP_IF_NONE_MATCH']) && $this->storage->hasEtag($server['HTTP_IF_NONE_MATCH']);
     }
 
     /**

--- a/src/HttpCache.php
+++ b/src/HttpCache.php
@@ -31,7 +31,7 @@ final class HttpCache implements HttpCacheInterface
     /**
      * {@inheritdoc}
      */
-    public function isNotModified(array $server)
+    public function isNotModified(array $server) : bool
     {
         if (! isset($server['HTTP_IF_NONE_MATCH'])) {
             return false;

--- a/src/HttpCache.php
+++ b/src/HttpCache.php
@@ -6,26 +6,16 @@
  */
 namespace BEAR\QueryRepository;
 
-use BEAR\RepositoryModule\Annotation\Storage;
-use Doctrine\Common\Cache\CacheProvider;
-
 final class HttpCache implements HttpCacheInterface
 {
-    const ETAG_KEY = 'etag:';
-
     /**
-     * @var CacheProvider
+     * @var ResourceStorageInterface
      */
-    private $kvs;
+    private $storage;
 
-    /**
-     * @param CacheProvider $kvs
-     *
-     * @Storage
-     */
-    public function __construct(CacheProvider $kvs)
+    public function __construct(ResourceStorageInterface $storage)
     {
-        $this->kvs = $kvs;
+        $this->storage = $storage;
     }
 
     /**
@@ -36,9 +26,8 @@ final class HttpCache implements HttpCacheInterface
         if (! isset($server['HTTP_IF_NONE_MATCH'])) {
             return false;
         }
-        $etagKey = self::ETAG_KEY . $server['HTTP_IF_NONE_MATCH'];
 
-        return $this->kvs->contains($etagKey) ? true : false;
+        return $this->storage->hasEtag($server['HTTP_IF_NONE_MATCH']);
     }
 
     /**

--- a/src/HttpCacheCli.php
+++ b/src/HttpCacheCli.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\QueryRepository;
+
+final class HttpCacheCli implements HttpCacheInterface
+{
+    /**
+     * @var ResourceStorageInterface
+     */
+    private $storage;
+
+    public function __construct(ResourceStorageInterface $storage)
+    {
+        $this->storage = $storage;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isNotModified(array $server) : bool
+    {
+        return isset($server['HTTP_IF_NONE_MATCH']) && $this->storage->hasEtag($server['HTTP_IF_NONE_MATCH']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transfer()
+    {
+        echo '304 Not Modified' . PHP_EOL . PHP_EOL;
+    }
+}

--- a/src/HttpCacheInterface.php
+++ b/src/HttpCacheInterface.php
@@ -17,4 +17,11 @@ interface HttpCacheInterface
      * @https://tools.ietf.org/html/rfc7232#section-4.1
      */
     public function isNotModified(array $server) : bool;
+
+    /**
+     * Transfer status code 304 to the client
+     *
+     * @return void
+     */
+    public function transfer();
 }

--- a/src/HttpCacheInterface.php
+++ b/src/HttpCacheInterface.php
@@ -20,8 +20,6 @@ interface HttpCacheInterface
 
     /**
      * Transfer status code 304 to the client
-     *
-     * @return void
      */
     public function transfer();
 }

--- a/src/HttpCacheInterface.php
+++ b/src/HttpCacheInterface.php
@@ -9,11 +9,12 @@ namespace BEAR\QueryRepository;
 interface HttpCacheInterface
 {
     /**
-     * Is not modified ?
+     * Is not modified ? (RFC7232 4.1)
      *
-     * @param array $server
+     * Indicates that a conditional GET or HEAD request has been received and would have resulted in a 200
+     * (OK) response if it were not for the fact that the condition evaluated to false.
      *
-     * @return bool
+     * @https://tools.ietf.org/html/rfc7232#section-4.1
      */
-    public function isNotModified(array $server);
+    public function isNotModified(array $server) : bool;
 }

--- a/src/HttpCacheWeb.php
+++ b/src/HttpCacheWeb.php
@@ -6,7 +6,7 @@
  */
 namespace BEAR\QueryRepository;
 
-final class HttpCache implements HttpCacheInterface
+final class HttpCacheWeb implements HttpCacheInterface
 {
     /**
      * @var ResourceStorageInterface
@@ -31,11 +31,6 @@ final class HttpCache implements HttpCacheInterface
      */
     public function transfer()
     {
-        if (PHP_SAPI === 'cli') {
-            echo '304 Not Modified' . PHP_EOL . PHP_EOL;
-
-            return;
-        }
         \http_response_code(304);
     }
 }

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -14,7 +14,6 @@ use BEAR\Resource\AbstractUri;
 use BEAR\Resource\RequestInterface;
 use BEAR\Resource\ResourceObject;
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Cache\Cache;
 
 class QueryRepository implements QueryRepositoryInterface
 {

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -184,7 +184,7 @@ class QueryRepository implements QueryRepositoryInterface
         if ($oldEtag) {
             $this->kvs->delete($oldEtag);
         }
-        $etagId = \BEAR\QueryRepository\HttpCache::ETAG_KEY . $etag;
+        $etagId = ResourceStorage::ETAG_PREFIX . $etag;
         $this->kvs->save($etagId, $uri);     // save etag
         $this->kvs->save($etagUri, $etagId); // save uri  mapping etag
     }

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -21,9 +21,9 @@ class QueryRepository implements QueryRepositoryInterface
     const ETAG_BY_URI = 'etag-by-uri';
 
     /**
-     * @var Cache
+     * @var ResourceStorageInterface
      */
-    private $kvs;
+    private $storage;
 
     /**
      * @var Reader
@@ -45,13 +45,13 @@ class QueryRepository implements QueryRepositoryInterface
      */
     public function __construct(
         EtagSetterInterface $setEtag,
-        Cache $kvs,
+        ResourceStorageInterface $storage,
         Reader $reader,
         Expiry $expiry
     ) {
         $this->setEtag = $setEtag;
         $this->reader = $reader;
-        $this->kvs = $kvs;
+        $this->storage = $storage;
         $this->expiry = $expiry;
     }
 
@@ -68,22 +68,21 @@ class QueryRepository implements QueryRepositoryInterface
         /* @var Cacheable $cacheable|null */
         ($this->setEtag)($ro, null, $httpCache);
         if (isset($ro->headers['ETag'])) {
-            $this->updateEtagDatabase($ro);
+            $this->storage->updateEtag($ro);
         }
         $body = $this->evaluateBody($ro->body);
         $lifeTime = $this->getExpiryTime($ro, $cacheable);
         $this->setMaxAge($ro, $lifeTime);
-        $id = $this->getVaryUri($ro->uri);
         if ($cacheable instanceof Cacheable && $cacheable->type === 'view') {
             if (! $ro->view) {
                 // render
                 $ro->view = $ro->toString();
             }
 
-            return $this->kvs->save($id, [$ro->uri, $ro->code, $ro->headers, $body, $ro->view], $lifeTime);
+            return $this->storage->saveView($ro, $lifeTime);
         }
         // "value" cache type
-        return $this->kvs->save($id, [$ro->uri, $ro->code, $ro->headers, $body, null], $lifeTime);
+        return $this->storage->saveValue($ro, $lifeTime);
     }
 
     /**
@@ -91,8 +90,7 @@ class QueryRepository implements QueryRepositoryInterface
      */
     public function get(AbstractUri $uri)
     {
-        $id = $this->getVaryUri($uri);
-        $data = $this->kvs->fetch($id);
+        $data = $this->storage->get($uri);
         if ($data === false) {
             return false;
         }
@@ -107,24 +105,9 @@ class QueryRepository implements QueryRepositoryInterface
      */
     public function purge(AbstractUri $uri)
     {
-        $id = $this->getVaryUri($uri);
-        $this->deleteEtagDatabase($uri);
+        $this->storage->deleteEtag($uri);
 
-        return $this->kvs->delete($id);
-    }
-
-    /**
-     * Delete etag in etag repository
-     *
-     * @param AbstractUri $uri
-     */
-    public function deleteEtagDatabase(AbstractUri $uri)
-    {
-        $etagId = self::ETAG_BY_URI . $this->getVaryUri($uri); // invalidate etag
-
-        $oldEtagKey = $this->kvs->fetch($etagId);
-
-        $this->kvs->delete($oldEtagKey);
+        return $this->storage->delete($uri);
     }
 
     /**
@@ -170,25 +153,6 @@ class QueryRepository implements QueryRepositoryInterface
         return $body;
     }
 
-    /**
-     * Update etag in etag repository
-     *
-     * @param ResourceObject $ro
-     */
-    private function updateEtagDatabase(ResourceObject $ro)
-    {
-        $etag = $ro->headers['ETag'];
-        $uri = (string) $ro->uri;
-        $etagUri = self::ETAG_BY_URI . $uri;
-        $oldEtag = $this->kvs->fetch($etagUri);
-        if ($oldEtag) {
-            $this->kvs->delete($oldEtag);
-        }
-        $etagId = ResourceStorage::ETAG_PREFIX . $etag;
-        $this->kvs->save($etagId, $uri);     // save etag
-        $this->kvs->save($etagUri, $etagId); // save uri  mapping etag
-    }
-
     private function getExpiryTime(ResourceObject $ro, Cacheable $cacheable = null) : int
     {
         if ($cacheable === null) {
@@ -209,9 +173,8 @@ class QueryRepository implements QueryRepositoryInterface
             throw new ExpireAtKeyNotExists($msg);
         }
         $expiryAt = $ro->body[$cacheable->expiryAt];
-        $sec = \strtotime($expiryAt) - \time();
 
-        return $sec;
+        return \strtotime($expiryAt) - \time();
     }
 
     private function setMaxAge(ResourceObject $ro, int $age)
@@ -223,22 +186,5 @@ class QueryRepository implements QueryRepositoryInterface
             return;
         }
         $ro->headers['Cache-Control'] = $setMaxAge;
-    }
-
-    private function getVaryUri(AbstractUri $uri) : string
-    {
-        if (! isset($_SERVER['X_VARY'])) {
-            return (string) $uri;
-        }
-        $varys = \explode(',', $_SERVER['X_VARY']);
-        $varyId = '';
-        foreach ($varys as $vary) {
-            $phpVaryKey = \sprintf('X_%s', \strtoupper($vary));
-            if (isset($_SERVER[$phpVaryKey])) {
-                $varyId .= $_SERVER[$phpVaryKey];
-            }
-        }
-
-        return (string) $uri . $varyId;
     }
 }

--- a/src/QueryRepositoryModule.php
+++ b/src/QueryRepositoryModule.php
@@ -38,5 +38,6 @@ class QueryRepositoryModule extends AbstractModule
         $this->bind()->annotatedWith(CacheVersion::class)->toInstance('');
         $this->bind(RefreshInterceptor::class);
         $this->install(new QueryRepositoryAopModule);
+        $this->bind(ResourceStorageInterface::class)->to(ResourceStorage::class);
     }
 }

--- a/src/QueryRepositoryModule.php
+++ b/src/QueryRepositoryModule.php
@@ -33,7 +33,7 @@ class QueryRepositoryModule extends AbstractModule
         $this->bind(EtagSetterInterface::class)->to(EtagSetter::class)->in(Scope::SINGLETON);
         $this->bind(NamedParameterInterface::class)->to(NamedParameter::class)->in(Scope::SINGLETON);
         $this->bind(Reader::class)->to(AnnotationReader::class)->in(Scope::SINGLETON);
-        $this->bind(HttpCacheInterface::class)->to(HttpCache::class);
+        $this->bind(HttpCacheInterface::class)->to(HttpCacheWeb::class);
         $this->bind()->annotatedWith(Commands::class)->toProvider(CommandsProvider::class);
         $this->bind()->annotatedWith(CacheVersion::class)->toInstance('');
         $this->bind(RefreshInterceptor::class);

--- a/src/RefreshSameCommand.php
+++ b/src/RefreshSameCommand.php
@@ -8,8 +8,6 @@ namespace BEAR\QueryRepository;
 
 use BEAR\QueryRepository\Exception\UnmatchedQuery;
 use BEAR\Resource\ResourceObject;
-use function is_callable;
-use function method_exists;
 use Ray\Aop\MethodInvocation;
 
 class RefreshSameCommand implements CommandInterface
@@ -40,7 +38,7 @@ class RefreshSameCommand implements CommandInterface
 
         // GET for re-generate (in interceptor)
         $ro->uri->query = $getQuery;
-        if (method_exists($ro, 'onGet')) {
+        if (\method_exists($ro, 'onGet')) {
             \call_user_func_array([$ro, 'onGet'], $getQuery);
         }
     }

--- a/src/RefreshSameCommand.php
+++ b/src/RefreshSameCommand.php
@@ -8,6 +8,8 @@ namespace BEAR\QueryRepository;
 
 use BEAR\QueryRepository\Exception\UnmatchedQuery;
 use BEAR\Resource\ResourceObject;
+use function is_callable;
+use function method_exists;
 use Ray\Aop\MethodInvocation;
 
 class RefreshSameCommand implements CommandInterface
@@ -29,7 +31,6 @@ class RefreshSameCommand implements CommandInterface
             return;
         }
         unset($invocation);
-        $onGet = [$ro, 'onGet'];
         $getQuery = $this->getQuery($ro);
         $delUri = clone $ro->uri;
         $delUri->query = $getQuery;
@@ -39,7 +40,9 @@ class RefreshSameCommand implements CommandInterface
 
         // GET for re-generate (in interceptor)
         $ro->uri->query = $getQuery;
-        \call_user_func_array($onGet, $getQuery);
+        if (method_exists($ro, 'onGet')) {
+            \call_user_func_array([$ro, 'onGet'], $getQuery);
+        }
     }
 
     /**

--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -18,6 +18,8 @@ final class ResourceStorage implements ResourceStorageInterface
 
     const ETAG_BY_URI = 'etag-by-uri';
 
+    const ETAG_PREFIX = 'etag-';
+
     /**
      * @var Cache
      */
@@ -36,15 +38,7 @@ final class ResourceStorage implements ResourceStorageInterface
      */
     public function hasEtag(string $etag) : bool
     {
-        return $this->cache->contains($etag);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setEtag(string $etag)
-    {
-        $this->cache->save($etag, self::MARK);
+        return $this->cache->contains(self::ETAG_PREFIX . $etag);
     }
 
     /**
@@ -97,7 +91,7 @@ final class ResourceStorage implements ResourceStorageInterface
         if ($oldEtag) {
             $this->cache->delete($oldEtag);
         }
-        $etagId = HttpCache::ETAG_KEY . $etag;
+        $etagId = self::ETAG_PREFIX . $etag;
         $this->cache->save($etagId, $uri);     // save etag
         $this->cache->save($etagUri, $etagId); // save uri  mapping etag
     }

--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -40,7 +40,7 @@ final class ResourceStorage implements ResourceStorageInterface
     }
 
     /**
-     * Update ETag
+     * {@inheritdoc}
      */
     public function updateEtag(ResourceObject $ro)
     {
@@ -56,9 +56,7 @@ final class ResourceStorage implements ResourceStorageInterface
     }
 
     /**
-     * Delete etag in etag repository
-     *
-     * @param AbstractUri $uri
+     * {@inheritdoc}
      */
     public function deleteEtag(AbstractUri $uri)
     {

--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -62,8 +62,8 @@ final class ResourceStorage implements ResourceStorageInterface
      */
     public function deleteEtag(AbstractUri $uri)
     {
-        $uri = self::ETAG_TABLE . $this->getVaryUri($uri); // invalidate etag
-        $oldEtagKey = $this->cache->fetch($uri);
+        $varyUri = self::ETAG_TABLE . $this->getVaryUri($uri); // invalidate etag
+        $oldEtagKey = $this->cache->fetch($varyUri);
 
         $this->cache->delete($oldEtagKey);
     }
@@ -73,9 +73,9 @@ final class ResourceStorage implements ResourceStorageInterface
      */
     public function get(AbstractUri $uri)
     {
-        $uri = $this->getVaryUri($uri);
+        $varyUri = $this->getVaryUri($uri);
 
-        return $this->cache->fetch($uri);
+        return $this->cache->fetch($varyUri);
     }
 
     /**
@@ -84,9 +84,9 @@ final class ResourceStorage implements ResourceStorageInterface
     public function delete(AbstractUri $uri) : bool
     {
         $this->deleteEtag($uri);
-        $uri = $this->getVaryUri($uri);
+        $varyUri = $this->getVaryUri($uri);
 
-        return $this->cache->delete($uri);
+        return $this->cache->delete($varyUri);
     }
 
     /**

--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\QueryRepository;
+
+use BEAR\RepositoryModule\Annotation\Storage;
+use BEAR\Resource\AbstractUri;
+use BEAR\Resource\RequestInterface;
+use BEAR\Resource\ResourceObject;
+use Doctrine\Common\Cache\Cache;
+
+final class ResourceStorage implements ResourceStorageInterface
+{
+    const MARK = '1';
+
+    const ETAG_BY_URI = 'etag-by-uri';
+
+    /**
+     * @var Cache
+     */
+    private $cache;
+
+    /**
+     * @Storage
+     */
+    public function __construct(Cache $etagRepo)
+    {
+        $this->cache = $etagRepo;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasEtag(string $etag) : bool
+    {
+        return $this->cache->contains($etag);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setEtag(string $etag)
+    {
+        $this->cache->save($etag, self::MARK);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get(AbstractUri $uri)
+    {
+        return $this->cache->fetch((string) $uri);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete(AbstractUri $uri) : bool
+    {
+        $this->deleteEtag($uri);
+
+        return $this->cache->delete((string) $uri);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveValue(ResourceObject $ro, int $lifeTime)
+    {
+        $body = $this->evaluateBody($ro->body);
+
+        return $this->cache->save((string) $ro->uri, [$ro->uri, $ro->code, $ro->headers, $body, null], $lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveView(ResourceObject $ro, int $lifeTime)
+    {
+        $body = $this->evaluateBody($ro->body);
+
+        return $this->cache->save((string) $ro->uri, [$ro->uri, $ro->code, $ro->headers, $body, $ro->view], $lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateEtag(ResourceObject $ro)
+    {
+        $etag = $ro->headers['ETag'];
+        $uri = (string) $ro->uri;
+        $etagUri = self::ETAG_BY_URI . $uri;
+        $oldEtag = $this->cache->fetch($etagUri);
+        if ($oldEtag) {
+            $this->cache->delete($oldEtag);
+        }
+        $etagId = HttpCache::ETAG_KEY . $etag;
+        $this->cache->save($etagId, $uri);     // save etag
+        $this->cache->save($etagUri, $etagId); // save uri  mapping etag
+    }
+
+    /**
+     * Delete etag in etag repository
+     *
+     * @param AbstractUri $uri
+     */
+    private function deleteEtag(AbstractUri $uri)
+    {
+        $etagId = self::ETAG_BY_URI . (string) $uri; // invalidate etag
+        $oldEtagKey = $this->cache->fetch($etagId);
+
+        $this->cache->delete($oldEtagKey);
+    }
+
+    private function evaluateBody($body)
+    {
+        if (! \is_array($body)) {
+            return $body;
+        }
+        foreach ($body as &$item) {
+            if ($item instanceof RequestInterface) {
+                $item = ($item)();
+            }
+        }
+
+        return $body;
+    }
+}

--- a/src/ResourceStorageInterface.php
+++ b/src/ResourceStorageInterface.php
@@ -12,14 +12,19 @@ use BEAR\Resource\ResourceObject;
 interface ResourceStorageInterface
 {
     /**
+     * Is ETag registered ?
+     */
+    public function hasEtag(string $etag) : bool;
+
+    /**
      * Update or save new Etag
      */
     public function updateEtag(ResourceObject $ro);
 
     /**
-     * Is ETag registered ?
+     * Delete Etag
      */
-    public function hasEtag(string $etag) : bool;
+    public function deleteEtag(AbstractUri $uri);
 
     /**
      * Get resource cache

--- a/src/ResourceStorageInterface.php
+++ b/src/ResourceStorageInterface.php
@@ -11,17 +11,35 @@ use BEAR\Resource\ResourceObject;
 
 interface ResourceStorageInterface
 {
-    public function setEtag(string $etag);
-
-    public function hasEtag(string $etag) : bool;
-
+    /**
+     * Update or save new Etag
+     */
     public function updateEtag(ResourceObject $ro);
 
+    /**
+     * Is ETag registered ?
+     */
+    public function hasEtag(string $etag) : bool;
+
+    /**
+     * Get resource cache
+     *
+     * @return [$uri, $code, $headers, $body, $view]]|false
+     */
     public function get(AbstractUri $uri);
 
+    /**
+     * Save resource cache with value
+     */
     public function saveValue(ResourceObject $ro, int $ttl);
 
+    /**
+     * Save resource cache with view
+     */
     public function saveView(ResourceObject $ro, int $ttl);
 
+    /**
+     * Delete resource cache
+     */
     public function delete(AbstractUri $uri) : bool;
 }

--- a/src/ResourceStorageInterface.php
+++ b/src/ResourceStorageInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace BEAR\QueryRepository;
+
+use BEAR\Resource\AbstractUri;
+use BEAR\Resource\ResourceObject;
+
+interface ResourceStorageInterface
+{
+    public function setEtag(string $etag);
+
+    public function hasEtag(string $etag) : bool;
+
+    public function updateEtag(ResourceObject $ro);
+
+    public function get(AbstractUri $uri);
+
+    public function saveValue(ResourceObject $ro, int $ttl);
+
+    public function saveView(ResourceObject $ro, int $ttl);
+
+    public function delete(AbstractUri $uri) : bool;
+}

--- a/src/ResourceStorageInterface.php
+++ b/src/ResourceStorageInterface.php
@@ -29,7 +29,9 @@ interface ResourceStorageInterface
     /**
      * Get resource cache
      *
-     * @return [$uri, $code, $headers, $body, $view]]|false
+     * return [$uri, $code, $headers, $body, $view]] array.
+     *
+     * @return array|false
      */
     public function get(AbstractUri $uri);
 

--- a/tests/BehaviorTest.php
+++ b/tests/BehaviorTest.php
@@ -30,7 +30,7 @@ class BehaviorTest extends TestCase
     private $repository;
 
     /**
-     * @var HttpCache
+     * @var HttpCacheInterface
      */
     private $httpCache;
 

--- a/tests/HttpCacheTest.php
+++ b/tests/HttpCacheTest.php
@@ -28,5 +28,16 @@ class HttpCacheTest extends TestCase
         $httpCache = new HttpCache($cache);
         $server = ['HTTP_IF_NONE_MATCH' => $etag];
         $this->assertTrue($httpCache->isNotModified($server));
+
+        return $httpCache;
+    }
+
+    /**
+     * @depends testisNotModifiedTrue
+     */
+    public function testTransfer(HttpCache $httpCache)
+    {
+        $this->expectOutputRegex('/\A304 Not Modified/');
+        $httpCache->transfer();
     }
 }

--- a/tests/HttpCacheTest.php
+++ b/tests/HttpCacheTest.php
@@ -16,7 +16,7 @@ class HttpCacheTest extends TestCase
 {
     public function testisNotModifiedFale()
     {
-        $httpCache = new HttpCache(new ResourceStorage(new ArrayCache));
+        $httpCache = new HttpCacheCli(new ResourceStorage(new ArrayCache));
         $server = [];
         $this->assertFalse($httpCache->isNotModified($server));
     }
@@ -27,7 +27,7 @@ class HttpCacheTest extends TestCase
         $user = $resource->get('app://self/user', ['id' => 1]);
         $storage = new ResourceStorage(new ArrayCache);
         $storage->updateEtag($user);
-        $httpCache = new HttpCache($storage);
+        $httpCache = new HttpCacheCli($storage);
         $server = ['HTTP_IF_NONE_MATCH' => $user->headers['ETag']];
         $this->assertTrue($httpCache->isNotModified($server));
 
@@ -37,7 +37,7 @@ class HttpCacheTest extends TestCase
     /**
      * @depends testisNotModifiedTrue
      */
-    public function testTransfer(HttpCache $httpCache)
+    public function testTransfer(HttpCacheCli $httpCache)
     {
         $this->expectOutputRegex('/\A304 Not Modified/');
         $httpCache->transfer();

--- a/tests/HttpCacheTest.php
+++ b/tests/HttpCacheTest.php
@@ -6,21 +6,27 @@
  */
 namespace BEAR\QueryRepository;
 
-use Doctrine\Common\Cache\VoidCache;
+use BEAR\Resource\Uri;
+use Doctrine\Common\Cache\ArrayCache;
 use PHPUnit\Framework\TestCase;
 
 class HttpCacheTest extends TestCase
 {
-    public function setUp()
+    public function testisNotModifiedFale()
     {
-        parent::setUp();
+        $httpCache = new HttpCache(new ArrayCache);
+        $server = [];
+        $this->assertFalse($httpCache->isNotModified($server));
     }
 
-    public function testPurgeSameResourceObjectByPatch()
+    public function testisNotModifiedTrue()
     {
-        $httpCache = new HttpCache(new VoidCache);
-        $server = [];
-        $result = $httpCache->isNotModified($server);
-        $this->assertFalse($result);
+        $cache = new ArrayCache;
+        $uri = new Uri('app://self/');
+        $etag = 'etag-1';
+        $cache->save(HttpCache::ETAG_KEY . $etag, (string) $uri);
+        $httpCache = new HttpCache($cache);
+        $server = ['HTTP_IF_NONE_MATCH' => $etag];
+        $this->assertTrue($httpCache->isNotModified($server));
     }
 }

--- a/tests/HttpCacheTest.php
+++ b/tests/HttpCacheTest.php
@@ -21,7 +21,7 @@ class HttpCacheTest extends TestCase
         $this->assertFalse($httpCache->isNotModified($server));
     }
 
-    public function testIsNotModifiedTrue()
+    public function testisNotModifiedTrue()
     {
         $resource = (new Injector(new QueryRepositoryModule(new ResourceModule('FakeVendor\HelloWorld'))))->getInstance(ResourceInterface::class);
         $user = $resource->get('app://self/user', ['id' => 1]);

--- a/tests/QueryRepositoryTest.php
+++ b/tests/QueryRepositoryTest.php
@@ -28,7 +28,7 @@ class QueryRepositoryTest extends TestCase
     private $repository;
 
     /**
-     * @var HttpCache
+     * @var HttpCacheInterface
      */
     private $httpCache;
 

--- a/tests/ResourceRepositoryTest.php
+++ b/tests/ResourceRepositoryTest.php
@@ -28,8 +28,14 @@ class ResourceRepositoryTest extends TestCase
 
     public function setUp()
     {
-        $this->repository = new Repository(new EtagSetter, new FilesystemCache($_ENV['TMP_DIR']), new AnnotationReader(), new Expiry(0, 0, 0));
-        /* @var $resource Resource */
+        $this->repository = new Repository(
+            new EtagSetter,
+            new ResourceStorage(
+                new FilesystemCache($_ENV['TMP_DIR'])
+            ),
+                new AnnotationReader,
+                new Expiry(0, 0, 0)
+        );
         $this->resourceObject = new Index;
         $this->resourceObject->uri = new Uri('page://self/user');
     }

--- a/tests/ResourceRepositoryTest.php
+++ b/tests/ResourceRepositoryTest.php
@@ -28,7 +28,7 @@ class ResourceRepositoryTest extends TestCase
 
     public function setUp()
     {
-        $this->repository = new Repository(new EtagSetter, new FilesystemCache($_ENV['TMP_DIR']), new AnnotationReader, new Expiry(0, 0, 0));
+        $this->repository = new Repository(new EtagSetter, new FilesystemCache($_ENV['TMP_DIR']), new AnnotationReader(), new Expiry(0, 0, 0));
         /* @var $resource Resource */
         $this->resourceObject = new Index;
         $this->resourceObject->uri = new Uri('page://self/user');


### PR DESCRIPTION
HttpCache::transfer() transfer http code 304 (NotModifed) to clients with no body.

 * `HttpCacheCli::transfer()` outputs with `echo()`
 * `HttpCacheWeb::transfer()` outputs with `http_response_code()`
