### PR TITLE
remove 'public' directive

### DIFF
--- a/src-annotation/HttpCache.php
+++ b/src-annotation/HttpCache.php
@@ -80,7 +80,10 @@ final class HttpCache extends AbstractCacheControl
 
     public function __toString()
     {
-        $control = $this->isPrivate ? ['private'] : ['public'];
+        $control = [];
+        if ($this->isPrivate) {
+            $control[] = 'private';
+        }
         if ($this->noCache) {
             $control[] = 'no-cache';
         }

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -166,12 +166,17 @@ final class QueryRepository implements QueryRepositoryInterface
     private function setMaxAge(ResourceObject $ro, int $age)
     {
         $setMaxAge = \sprintf('max-age=%d', $age);
-        if (isset($ro->headers['Cache-Control'])) {
-            $ro->headers['Cache-Control'] .= ', ' . $setMaxAge;
+        $noCacheControleHeader = ! isset($ro->headers['Cache-Control']);
+        if ($noCacheControleHeader) {
+            $ro->headers['Cache-Control'] = $setMaxAge;
 
             return;
         }
-        $ro->headers['Cache-Control'] = $setMaxAge;
+        $isMaxAgeAlreadyDefined = strpos($ro->headers['Cache-Control'], 'max-age') !== false;
+        if ($isMaxAgeAlreadyDefined) {
+            return;
+        }
+        $ro->headers['Cache-Control'] .= ', ' . $setMaxAge;
     }
 
     private function saveViewCache(ResourceObject $ro, int $lifeTime)

--- a/tests/BehaviorTest.php
+++ b/tests/BehaviorTest.php
@@ -45,12 +45,12 @@ class BehaviorTest extends TestCase
     public function testPurgeSameResourceObjectByPatch()
     {
         /** @var ResourceObject $user */
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $etag = $user->headers['ETag'];
         // reload (purge repository entry and re-generate by onGet)
-        $this->resource->patch->uri('app://self/user')->withQuery(['id' => 1, 'name' => 'kuma'])->eager->request();
+        $this->resource->patch('app://self/user', ['id' => 1, 'name' => 'kuma']);
         // load from repository, not invoke onGet method
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $newEtag = $user->headers['ETag'];
         $this->assertFalse($etag === $newEtag);
     }
@@ -58,7 +58,7 @@ class BehaviorTest extends TestCase
     public function testPurgeSameResourceObjectByDelete()
     {
         /** @var ResourceObject $user */
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $etag = $user->headers['ETag'];
         $server = [
             'REQUEST_METHOD' => 'GET',
@@ -66,8 +66,8 @@ class BehaviorTest extends TestCase
         ];
         $isNotModified = $this->httpCache->isNotModified($server);
         $this->assertTrue($isNotModified);
-        $this->resource->delete->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $this->resource->delete('app://self/user', ['id' => 1]);
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $newEtag = $user->headers['ETag'];
         $this->assertFalse($etag === $newEtag);
         $isNotModified = $this->httpCache->isNotModified($server);
@@ -76,25 +76,25 @@ class BehaviorTest extends TestCase
 
     public function testPurgeByAnnotation()
     {
-        $this->resource->put->uri('app://self/user')->withQuery(['id' => 1, 'age' => 10, 'name' => 'Sunday'])->eager->request();
+        $this->resource->put('app://self/user', ['id' => 1, 'age' => 10, 'name' => 'Sunday']);
         $this->assertTrue(Profile::$requested);
     }
 
     public function testReturnValueIsNotResourceObjectException()
     {
         $this->expectException(ReturnValueIsNotResourceObjectException::class);
-        $this->resource->put->uri('app://self/invalid')->withQuery(['id' => 1, 'age' => 10, 'name' => 'Sunday'])->eager->request();
+        $this->resource->put('app://self/invalid', ['id' => 1, 'age' => 10, 'name' => 'Sunday']);
     }
 
     public function testUnMatchQuery()
     {
         $this->expectException(UnmatchedQuery::class);
-        $this->resource->put->uri('app://self/unmatch')->withQuery(['id' => 1, 'age' => 10, 'name' => 'Sunday'])->eager->request();
+        $this->resource->put('app://self/unmatch', ['id' => 1, 'age' => 10, 'name' => 'Sunday']);
     }
 
     public function testCacheCode()
     {
-        $ro = $this->resource->get->uri('app://self/code')->withQuery([])->eager->request(); // 1
+        $ro = $this->resource->get('app://self/code', []); // 1
         /* @var $ro Code */
         $ro->code = 203;
         $ro->onGet(); // 2 non-caached
@@ -110,14 +110,14 @@ class BehaviorTest extends TestCase
     public function testRefreshWithCacheableAnnotation()
     {
         RefreshDest::$id = 0;
-        $this->resource->put->uri('app://self/refresh-cache-src')(['id' => '1']);
+        $this->resource->put('app://self/refresh-cache-src', ['id' => '1']);
         $this->assertSame('1', RefreshDest::$id);
     }
 
     public function testRefreshWithoutCacheableAnnotation()
     {
         RefreshDest::$id = 0;
-        $this->resource->put->uri('app://self/refresh-src')(['id' => '1']);
+        $this->resource->put('app://self/refresh-src', ['id' => '1']);
         $this->assertSame('1', RefreshDest::$id);
     }
 }

--- a/tests/BehaviorTest.php
+++ b/tests/BehaviorTest.php
@@ -94,8 +94,8 @@ class BehaviorTest extends TestCase
 
     public function testCacheCode()
     {
+        /** @var Code $ro */
         $ro = $this->resource->get('app://self/code', []); // 1
-        /* @var $ro Code */
         $ro->code = 203;
         $ro->onGet(); // 2 non-caached
         $ro->code = 500;

--- a/tests/CacheTypeTest.php
+++ b/tests/CacheTypeTest.php
@@ -24,13 +24,13 @@ class CacheTypeTest extends TestCase
 
     public function requestDobule($uri)
     {
-        $ro = $this->resource->get->uri($uri)->eager->request();
+        $ro = $this->resource->get($uri);
         // put
         $expect = 'Last-Modified';
         $this->assertArrayHasKey($expect, $ro->headers);
         $time = $ro['time'];
         // get
-        $ro = $this->resource->get->uri($uri)->eager->request();
+        $ro = $this->resource->get($uri);
         $this->assertArrayHasKey($expect, $ro->headers);
         $expect = $time;
         $this->assertSame($expect, $ro['time']);
@@ -42,11 +42,11 @@ class CacheTypeTest extends TestCase
     {
         $uri = 'app://self/value';
         // put
-        $ro = $this->resource->get->uri($uri)->eager->request();
+        $ro = $this->resource->get($uri);
         (string) $ro;
         $time = $ro['time'];
         $this->assertSame('1' . $time, $ro->view);
-        $ro = $this->resource->get->uri($uri)->eager->request();
+        $ro = $this->resource->get($uri);
         (string) $ro;
         $this->assertSame('2' . $time, $ro->view);
     }
@@ -55,10 +55,10 @@ class CacheTypeTest extends TestCase
     {
         $uri = 'app://self/view';
         // put
-        $ro = $this->resource->get->uri($uri)->eager->request();
+        $ro = $this->resource->get($uri);
         $time = $ro['time'];
         $this->assertSame('1' . $time, $ro->view);
-        $ro = $this->resource->get->uri($uri)->eager->request();
+        $ro = $this->resource->get($uri);
         $this->assertTrue((bool) $ro->view);
         $this->assertSame('1' . $time, $ro->view);
     }

--- a/tests/EtagSetterTest.php
+++ b/tests/EtagSetterTest.php
@@ -24,7 +24,7 @@ class EtagSetterTest extends TestCase
 
     public function testInvoke()
     {
-        $ro = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $ro = $this->resource->get('app://self/user', ['id' => 1]);
         $setEtag = new EtagSetter;
         $time = 0;
         $setEtag($ro, $time);

--- a/tests/Fake/fake-app/src/Resource/App/HttpCacheControlOverrideMaxAge.php
+++ b/tests/Fake/fake-app/src/Resource/App/HttpCacheControlOverrideMaxAge.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\RepositoryModule\Annotation\HttpCache;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable(expirySecond=10)
+ * @HttpCache(maxAge=5)
+ */
+class HttpCacheControlOverrideMaxAge extends ResourceObject
+{
+    public function onGet() : ResourceObject
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/App/HttpCacheControlWithCacheable.php
+++ b/tests/Fake/fake-app/src/Resource/App/HttpCacheControlWithCacheable.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\RepositoryModule\Annotation\HttpCache;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable(expirySecond=10)
+ * @HttpCache(isPrivate=true)
+ */
+class HttpCacheControlWithCacheable extends ResourceObject
+{
+    public function onGet() : ResourceObject
+    {
+        return $this;
+    }
+}

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -25,13 +25,13 @@ class GetInterceptorTest extends TestCase
 
     public function testLastModifiedHeader()
     {
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         // put
         $expect = 'Last-Modified';
         $this->assertArrayHasKey($expect, $user->headers);
         $time = $user['time'];
         // get
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $this->assertArrayHasKey($expect, $user->headers);
         $expect = $time;
         $this->assertSame($expect, $user['time']);
@@ -39,14 +39,14 @@ class GetInterceptorTest extends TestCase
 
     public function testCacheControlHeaderNone()
     {
-        $user = $this->resource->get->uri('app://self/control-none')->eager->request();
+        $user = $this->resource->get('app://self/control-none');
         $this->assertArrayHasKey('Cache-Control', $user->headers);
         $this->assertSame('max-age=60', $user->headers['Cache-Control']);
     }
 
     public function testCacheControlHeaderExpiry()
     {
-        $user = $this->resource->get->uri('app://self/control-expiry')->eager->request();
+        $user = $this->resource->get('app://self/control-expiry');
         $this->assertArrayHasKey('Cache-Control', $user->headers);
         $this->assertContains('public, max-age=3', $user->headers['Cache-Control']); // 30 sec (but may 30+x sec for slow CI)
     }
@@ -54,50 +54,50 @@ class GetInterceptorTest extends TestCase
     public function testCacheControlHeaderExpiryError()
     {
         $this->expectException(ExpireAtKeyNotExists::class);
-        $this->resource->get->uri('app://self/control-expiry-error')->eager->request();
+        $this->resource->get('app://self/control-expiry-error');
     }
 
     public function testHttpCacheAnnotation()
     {
-        $ro = $this->resource->get->uri('app://self/http-cache-control')->eager->request();
+        $ro = $this->resource->get('app://self/http-cache-control');
         $this->assertSame($ro->headers['Cache-Control'], 'private, no-cache, no-store, must-revalidate');
     }
 
     public function testNoHttpCacheAnnotation()
     {
-        $ro = $this->resource->get->uri('app://self/no-http-cache-control')->eager->request();
+        $ro = $this->resource->get('app://self/no-http-cache-control');
         $this->assertSame($ro->headers['Cache-Control'], 'private, no-store, no-cache, must-revalidate');
     }
 
     public function testHttpCacheWithCacheble()
     {
-        $ro = $this->resource->get->uri('app://self/http-cache-control-with-cacheable')->eager->request();
+        $ro = $this->resource->get('app://self/http-cache-control-with-cacheable');
         $this->assertSame($ro->headers['Cache-Control'], 'private, max-age=10');
     }
 
     public function testHttpCacheOverrideMaxAge()
     {
-        $ro = $this->resource->get->uri('app://self/http-cache-control-override-max-age')->eager->request();
+        $ro = $this->resource->get('app://self/http-cache-control-override-max-age');
         $this->assertSame($ro->headers['Cache-Control'], 'max-age=5');
     }
 
     public function testHttpCacheEtag()
     {
-        $ro1 = $this->resource->get->uri('app://self/etag')->eager->request();
-        $ro2 = $this->resource->get->uri('app://self/etag')->eager->request();
-        $ro3 = $this->resource->get->uri('app://self/etag')->withQuery(['updatedAt' => 1])->eager->request();
+        $ro1 = $this->resource->get('app://self/etag');
+        $ro2 = $this->resource->get('app://self/etag');
+        $ro3 = $this->resource->get('app://self/etag', ['updatedAt' => 1]);
         $this->assertSame($ro1->headers['ETag'], $ro2->headers['ETag']);
         $this->assertNotSame($ro1->headers['ETag'], $ro3->headers['ETag']);
     }
 
     public function testHttpCacheVary()
     {
-        $ro1 = $this->resource->get->uri('app://self/etag')->eager->request();
-        $ro2 = $this->resource->get->uri('app://self/etag')->eager->request();
+        $ro1 = $this->resource->get('app://self/etag');
+        $ro2 = $this->resource->get('app://self/etag');
         $_SERVER['X_VARY'] = 'val1, val2';
         $_SERVER['X_VAL1'] = '1';
         $_SERVER['X_VAL2'] = '2';
-        $ro3 = $this->resource->get->uri('app://self/etag')->eager->request();
+        $ro3 = $this->resource->get('app://self/etag');
         $this->assertArrayNotHasKey('Age', $ro1->headers);
         $this->assertArrayHasKey('Age', $ro2->headers);
         $this->assertArrayNotHasKey('Age', $ro3->headers);

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -69,6 +69,18 @@ class GetInterceptorTest extends TestCase
         $this->assertSame($ro->headers['Cache-Control'], 'private, no-store, no-cache, must-revalidate');
     }
 
+    public function testHttpCacheWithCacheble()
+    {
+        $ro = $this->resource->get->uri('app://self/http-cache-control-with-cacheable')->eager->request();
+        $this->assertSame($ro->headers['Cache-Control'], 'private, max-age=10');
+    }
+
+    public function testHttpCacheOverrideMaxAge()
+    {
+        $ro = $this->resource->get->uri('app://self/http-cache-control-override-max-age')->eager->request();
+        $this->assertSame($ro->headers['Cache-Control'], 'max-age=5');
+    }
+
     public function testHttpCacheEtag()
     {
         $ro1 = $this->resource->get->uri('app://self/etag')->eager->request();

--- a/tests/QueryRepositoryTest.php
+++ b/tests/QueryRepositoryTest.php
@@ -91,7 +91,7 @@ class QueryRepositoryTest extends TestCase
 
     public function testPutResquestEmbeddedResoureView()
     {
-        $uri ='page://self/emb-view';
+        $uri = 'page://self/emb-view';
         $ro = $this->resource->get($uri);
         $this->repository->put($ro);
         list(, , , $body, $view) = $this->repository->get(new Uri($uri));

--- a/tests/QueryRepositoryTest.php
+++ b/tests/QueryRepositoryTest.php
@@ -43,12 +43,12 @@ class QueryRepositoryTest extends TestCase
     public function testPurgeSameResourceObjectByPatch()
     {
         /** @var ResourceObject $user */
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $etag = $user->headers['ETag'];
         // reload (purge repository entry and re-generate by onGet)
-        $this->resource->patch->uri('app://self/user')->withQuery(['id' => 1, 'name' => 'kuma'])->eager->request();
+        $this->resource->patch('app://self/user', ['id' => 1, 'name' => 'kuma']);
         // load from repository, not invoke onGet method
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $newEtag = $user->headers['ETag'];
         $this->assertFalse($etag === $newEtag);
     }
@@ -56,7 +56,7 @@ class QueryRepositoryTest extends TestCase
     public function testPurgeSameResourceObjectByDelete()
     {
         /** @var ResourceObject $user */
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $etag = $user->headers['ETag'];
         $server = [
             'REQUEST_METHOD' => 'GET',
@@ -64,8 +64,8 @@ class QueryRepositoryTest extends TestCase
         ];
         $isNotModified = $this->httpCache->isNotModified($server);
         $this->assertTrue($isNotModified);
-        $this->resource->delete->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $this->resource->delete('app://self/user', ['id' => 1]);
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $newEtag = $user->headers['ETag'];
         $this->assertFalse($etag === $newEtag);
         $isNotModified = $this->httpCache->isNotModified($server);
@@ -74,7 +74,7 @@ class QueryRepositoryTest extends TestCase
 
     public function testPurgeByAnnotation()
     {
-        $this->resource->put->uri('app://self/user')->withQuery(['id' => 1, 'age' => 10, 'name' => 'Sunday'])->eager->request();
+        $this->resource->put('app://self/user', ['id' => 1, 'age' => 10, 'name' => 'Sunday']);
         $this->assertTrue(Profile::$requested);
     }
 
@@ -91,10 +91,10 @@ class QueryRepositoryTest extends TestCase
 
     public function testPutResquestEmbeddedResoureView()
     {
-        $uri = new Uri('page://self/emb-view');
-        $ro = $this->resource->uri($uri)();
+        $uri ='page://self/emb-view';
+        $ro = $this->resource->get($uri);
         $this->repository->put($ro);
-        list(, , , $body, $view) = $this->repository->get($uri);
+        list(, , , $body, $view) = $this->repository->get(new Uri($uri));
         $this->assertInstanceOf(None::class, $body['time']);
         $this->assertSame(1, $body['num']);
         $this->assertSame('{
@@ -106,10 +106,10 @@ class QueryRepositoryTest extends TestCase
 
     public function testPutResquestEmbeddedResoureValue()
     {
-        $uri = new Uri('page://self/emb-val');
-        $ro = $this->resource->uri($uri)();
+        $uri = 'page://self/emb-val';
+        $ro = $this->resource->get($uri);
         $this->repository->put($ro);
-        list(, , , $body, $view) = $this->repository->get($uri);
+        list(, , , $body, $view) = $this->repository->get(new Uri($uri));
         $this->assertInstanceOf(None::class, $body['time']);
         $this->assertSame(1, $body['num']);
         $this->assertNull($view);

--- a/tests/ReloadAnnotatedCommandTest.php
+++ b/tests/ReloadAnnotatedCommandTest.php
@@ -24,13 +24,13 @@ class ReloadAnnotatedCommandTest extends TestCase
 
     public function testInvoke()
     {
-        $user = $this->resource->patch->uri('app://self/user')->withQuery(['id' => 1, 'name' => 'koriym'])->eager->request();
+        $user = $this->resource->patch('app://self/user', ['id' => 1, 'name' => 'koriym']);
         // put
         $expect = 'Last-Modified';
         $this->assertArrayHasKey($expect, $user->headers);
         $time = $user['time'];
         // get
-        $user = $this->resource->get->uri('app://self/user')->withQuery(['id' => 1])->eager->request();
+        $user = $this->resource->get('app://self/user', ['id' => 1]);
         $this->assertArrayHasKey($expect, $user->headers);
         $expect = $time;
         $this->assertSame($expect, $user['time']);


### PR DESCRIPTION
* Marking 'public' is not necessary except edge cases like in authentication or non-cacheable status code. source: https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/http-caching?hl=ja

* `@HttpCache` `max-age` has priority over `@Cacheable` expiry time.