### PR TITLE
ETag depends on vary uri

### DIFF
--- a/src/EtagSetter.php
+++ b/src/EtagSetter.php
@@ -9,6 +9,8 @@ use BEAR\Resource\ResourceObject;
 
 final class EtagSetter implements EtagSetterInterface
 {
+    use VaryUriTrait;
+
     /**
      * {@inheritdoc}
      */
@@ -36,7 +38,7 @@ final class EtagSetter implements EtagSetterInterface
 
     public function getEtagByEitireView(ResourceObject $ro) : string
     {
-        return \get_class($ro) . \serialize($ro->view);
+        return \serialize($ro->view);
     }
 
     /**
@@ -50,6 +52,6 @@ final class EtagSetter implements EtagSetterInterface
     {
         $etag = $httpCache instanceof HttpCache && $httpCache->etag ? $this->getEtagByPartialBody($httpCache, $ro) : $this->getEtagByEitireView($ro);
 
-        return (string) \crc32(\get_class($ro) . $etag);
+        return (string) \crc32($this->getVaryUri($ro->uri) . $etag);
     }
 }

--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -12,6 +12,8 @@ use Doctrine\Common\Cache\CacheProvider;
 
 final class ResourceStorage implements ResourceStorageInterface
 {
+    use VaryUriTrait;
+
     /**
      * Prefix for ETag URI
      */
@@ -127,22 +129,5 @@ final class ResourceStorage implements ResourceStorageInterface
         }
 
         return $body;
-    }
-
-    private function getVaryUri(AbstractUri $uri) : string
-    {
-        if (! isset($_SERVER['X_VARY'])) {
-            return (string) $uri;
-        }
-        $varys = \explode(',', $_SERVER['X_VARY']);
-        $varyId = '';
-        foreach ($varys as $vary) {
-            $phpVaryKey = \sprintf('X_%s', \strtoupper($vary));
-            if (isset($_SERVER[$phpVaryKey])) {
-                $varyId .= $_SERVER[$phpVaryKey];
-            }
-        }
-
-        return (string) $uri . $varyId;
     }
 }

--- a/src/VaryUriTrait.php
+++ b/src/VaryUriTrait.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QueryRepository;
+
+use BEAR\Resource\AbstractUri;
+
+trait VaryUriTrait
+{
+    private function getVaryUri(AbstractUri $uri) : string
+    {
+        if (! isset($_SERVER['X_VARY'])) {
+            return (string) $uri;
+        }
+        $varys = \explode(',', $_SERVER['X_VARY']);
+        $varyId = '';
+        foreach ($varys as $vary) {
+            $phpVaryKey = \sprintf('X_%s', \strtoupper($vary));
+            if (isset($_SERVER[$phpVaryKey])) {
+                $varyId .= $_SERVER[$phpVaryKey];
+            }
+        }
+
+        return (string) $uri . $varyId;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/App/SometimesSameResponse.php
+++ b/tests/Fake/fake-app/src/Resource/App/SometimesSameResponse.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * This file is part of the BEAR.QueryRepository package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace FakeVendor\HelloWorld\Resource\App;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable
+ */
+class SometimesSameResponse extends ResourceObject
+{
+    private $data = [
+        1 => 'same message',
+        2 => 'same message',
+        3 => 'same message',
+        4 => 'different message',
+    ];
+
+    public function onGet($id)
+    {
+        $this['message'] = isset($this->data[$id]) ? $this->data[$id] : '';
+
+        return $this;
+    }
+
+    public function onDelete($id)
+    {
+        unset($this->data[$id]);
+
+        return $this;
+    }
+}

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -101,5 +101,9 @@ class GetInterceptorTest extends TestCase
         $this->assertArrayNotHasKey('Age', $ro1->headers);
         $this->assertArrayHasKey('Age', $ro2->headers);
         $this->assertArrayNotHasKey('Age', $ro3->headers);
+
+        unset($_SERVER['X_VARY']);
+        unset($_SERVER['X_VAL1']);
+        unset($_SERVER['X_VAL2']);
     }
 }

--- a/tests/GetInterceptorTest.php
+++ b/tests/GetInterceptorTest.php
@@ -102,8 +102,6 @@ class GetInterceptorTest extends TestCase
         $this->assertArrayHasKey('Age', $ro2->headers);
         $this->assertArrayNotHasKey('Age', $ro3->headers);
 
-        unset($_SERVER['X_VARY']);
-        unset($_SERVER['X_VAL1']);
-        unset($_SERVER['X_VAL2']);
+        unset($_SERVER['X_VARY'], $_SERVER['X_VAL1'], $_SERVER['X_VAL2']);
     }
 }

--- a/tests/QueryRepositoryTest.php
+++ b/tests/QueryRepositoryTest.php
@@ -114,4 +114,26 @@ class QueryRepositoryTest extends TestCase
         $this->assertSame(1, $body['num']);
         $this->assertNull($view);
     }
+
+    public function testSameResponseButDifferentParameter()
+    {
+        $ro1 = $this->resource->get('app://self/sometimes-same-response', ['id' => 1]);
+        $server1 = [
+            'REQUEST_METHOD' => 'GET',
+            'HTTP_IF_NONE_MATCH' => $ro1->headers['ETag'],
+        ];
+        $this->assertTrue($this->httpCache->isNotModified($server1), 'id:1 is not modified');
+
+        $ro2 = $this->resource->get('app://self/sometimes-same-response', ['id' => 2]);
+        $server2 = [
+            'REQUEST_METHOD' => 'GET',
+            'HTTP_IF_NONE_MATCH' => $ro2->headers['ETag'],
+        ];
+        $this->assertTrue($this->httpCache->isNotModified($server2), 'id:2 is not modified');
+
+        $this->resource->delete('app://self/sometimes-same-response', ['id' => 1]);
+
+        $this->assertFalse($this->httpCache->isNotModified($server1), 'id:1 is modified');
+        $this->assertTrue($this->httpCache->isNotModified($server2), 'id:2 is not modified');
+    }
 }


### PR DESCRIPTION
## 概要

この対応方法が良いのか分かりませんが、 ETag の生成を Vary Uri に依存するようにしてみました。

## 背景

同じリソースクラス、別のパラメーターで同じレスポンスを返すこともあるAPIがありまして、
このリソースクラスに5分間キャッシュする設定（`@Cacheable`）を入れていました。

そして下記のようなリクエストをし、

1. `/foo?param=a` をリクエスト
2. その1分後に `/foo?param=b` リクエスト

そのどちらも同じレスポンスが返ってしまうと、現状では同じETagを返すので、
リクエスト後すぐに `If-None-Match` でリクエストすると、どちらも 304 が返るかと思います。

`1.` をリクエストしてから5分後に`If-None-Match` でリクエストすると、5分しかキャッシュが効かないはずなのに、304 が返ります。
これは `2.` のタイミングで同じETag（`etag-val-*`）に対してさらに5分間キャッシュが延長されたからでした。

## その他の対応方法

`HttpCache::isNotModified` の処理を変えて、ETagの値とUriに依存させる。
そして `etag-val-*` のキャッシュキーにもuriを含める。
といった修正の方が良いような気もしましたが、修正範囲が大きくなるため、このPRの方法を取りました。


