### PR TITLE
Expiry accepts param $never

### DIFF
--- a/src/Expiry.php
+++ b/src/Expiry.php
@@ -9,12 +9,12 @@ namespace BEAR\QueryRepository;
  */
 class Expiry extends \ArrayObject
 {
-    public function __construct(int $short = 60, int $medium = 3600, int $long = 86400)
+    public function __construct(int $short = 60, int $medium = 3600, int $long = 86400, int $never = 31536000)
     {
         $this['short'] = $short;
         $this['medium'] = $medium;
         $this['long'] = $long;
-        $this['never'] = 0;
+        $this['never'] = $never;
         parent::__construct();
     }
 }


### PR DESCRIPTION
default 1 year, 31536000

redis `volatile-lru` algrism can delete the cache.