### PR TITLE
Convert resource object  to resource body to store cache storage

### DIFF
--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -125,7 +125,7 @@ final class ResourceStorage implements ResourceStorageInterface
                 $item = ($item)();
             }
             if ($item instanceof ResourceObject) {
-                $item = $item->body;
+                $item->body = $this->evaluateBody($item->body);
             }
         }
 

--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -124,6 +124,9 @@ final class ResourceStorage implements ResourceStorageInterface
             if ($item instanceof RequestInterface) {
                 $item = ($item)();
             }
+            if ($item instanceof ResourceObject) {
+                $item = $item->body;
+            }
         }
 
         return $body;

--- a/tests/Fake/fake-app/src/Resource/Page/None.php
+++ b/tests/Fake/fake-app/src/Resource/Page/None.php
@@ -10,10 +10,12 @@ use BEAR\Resource\ResourceObject;
 
 class None extends ResourceObject
 {
-    public function onGet()
+    public function onGet() : ResourceObject
     {
         $this->body = [
-            'time' => \microtime(true)
+            'none' => 'none'
         ];
+
+        return $this;
     }
 }

--- a/tests/QueryRepositoryTest.php
+++ b/tests/QueryRepositoryTest.php
@@ -99,10 +99,11 @@ class QueryRepositoryTest extends TestCase
         $ro = $this->resource->get($uri);
         $this->repository->put($ro);
         [, , , $body, $view] = $this->repository->get(new Uri($uri));
-        $this->assertInstanceOf(None::class, $body['time']);
         $this->assertSame(1, $body['num']);
         $this->assertSame('{
-    "time": null,
+    "time": {
+        "none": "none"
+    },
     "num": 1
 }
 ', $view);
@@ -114,7 +115,6 @@ class QueryRepositoryTest extends TestCase
         $ro = $this->resource->get($uri);
         $this->repository->put($ro);
         [, , , $body, $view] = $this->repository->get(new Uri($uri));
-        $this->assertInstanceOf(None::class, $body['time']);
         $this->assertSame(1, $body['num']);
         $this->assertNull($view);
     }


### PR DESCRIPTION
Do not store ResourceObject class to cache storage. Store resource object's body instead.

* Save storage space and time.
* Improve stability between deploy version  (do not require to keep same class name = accept AOP suffix change)