### PR TITLE
Invalidate the cache and the etag when the embedded resource is modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /coverage.xml
 /vendor-bin/**/vendor
 /.php_cs.cache
+/.phpunit-cache/

--- a/src/CacheDependency.php
+++ b/src/CacheDependency.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QueryRepository;
+
+use BEAR\Resource\ResourceObject;
+
+use function assert;
+use function sprintf;
+
+class CacheDependency implements CacheDependencyInterface
+{
+    public const CACHE_DEPENDENCY = 'cache_deps';
+
+    public function depends(ResourceObject $from, ResourceObject $to): void
+    {
+        assert(! isset($from->headers[self::CACHE_DEPENDENCY]));
+
+        $cacheDepedencyTags = $to->headers['ETag'];
+        if (isset($to->headers[self::CACHE_DEPENDENCY])) {
+            $cacheDepedencyTags .= sprintf(' %s', $to->headers[self::CACHE_DEPENDENCY]);
+            unset($to->headers[self::CACHE_DEPENDENCY]);
+        }
+
+        $from->headers[self::CACHE_DEPENDENCY] = $cacheDepedencyTags;
+    }
+}

--- a/src/CacheDependencyInterface.php
+++ b/src/CacheDependencyInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QueryRepository;
+
+use BEAR\Resource\ResourceObject;
+
+interface CacheDependencyInterface
+{
+    public function depends(ResourceObject $from, ResourceObject $to): void;
+}

--- a/src/QueryRepositoryModule.php
+++ b/src/QueryRepositoryModule.php
@@ -21,6 +21,7 @@ class QueryRepositoryModule extends AbstractModule
     {
         $this->install(new Psr6ArrayModule());
         $this->bind(QueryRepositoryInterface::class)->to(QueryRepository::class)->in(Scope::SINGLETON);
+        $this->bind(CacheDependencyInterface::class)->to(CacheDependency::class);
         $this->bind(EtagSetterInterface::class)->to(EtagSetter::class)->in(Scope::SINGLETON);
         $this->bind(NamedParameterInterface::class)->to(NamedParameter::class)->in(Scope::SINGLETON);
         $this->bind(HttpCacheInterface::class)->to(HttpCache::class);

--- a/tests/CacheDependencyTest.php
+++ b/tests/CacheDependencyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QueryRepository;
+
+use BEAR\Resource\Module\ResourceModule;
+use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\Uri;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+class CacheDependencyTest extends TestCase
+{
+    /** @var ResourceInterface */
+    private $resource;
+
+    /** @var QueryRepository */
+    private $repository;
+
+    protected function setUp(): void
+    {
+        $namespace = 'FakeVendor\HelloWorld';
+        $injector = new Injector(new FakeEtagPoolModule(new QueryRepositoryModule(new ResourceModule($namespace))), $_ENV['TMP_DIR']);
+        $this->repository = $injector->getInstance(QueryRepositoryInterface::class);
+        $this->resource = $injector->getInstance(ResourceInterface::class);
+        parent::setUp();
+    }
+
+    public function testDestroyByChild(): void
+    {
+        $this->resource->get('page://self/dep/level-one');
+        $one1 = $this->repository->get(new Uri('page://self/dep/level-one'));
+        $this->assertInstanceOf(ResourceState::class, $one1);
+        // destroy by child
+        $this->repository->purge(new Uri('page://self/dep/level-two'));
+        $one2 = $this->repository->get(new Uri('page://self/dep/level-one'));
+        $this->assertNull($one2);
+    }
+
+    public function testDestroyByGrandChild(): void
+    {
+        $this->resource->get('page://self/dep/level-one');
+        $one1 = $this->repository->get(new Uri('page://self/dep/level-one'));
+        $this->assertInstanceOf(ResourceState::class, $one1);
+        $this->repository->purge(new Uri('page://self/dep/level-three'));
+        $one2 = $this->repository->get(new Uri('page://self/dep/level-one'));
+        $this->assertNull($one2);
+    }
+}

--- a/tests/EtagSetterTest.php
+++ b/tests/EtagSetterTest.php
@@ -23,7 +23,7 @@ class EtagSetterTest extends TestCase
 
     public function testStatusNotOk(): void
     {
-        $setEtag = new EtagSetter();
+        $setEtag = new EtagSetter(new CacheDependency());
         $ro = new Code();
         $ro->code = 500;
         $setEtag($ro);
@@ -34,7 +34,7 @@ class EtagSetterTest extends TestCase
     public function testInvoke(): void
     {
         $ro = $this->resource->get('app://self/user', ['id' => 1]);
-        $setEtag = new EtagSetter();
+        $setEtag = new EtagSetter(new CacheDependency());
         $time = 0;
         $setEtag($ro, $time);
         $expect = 'Thu, 01 Jan 1970 00:00:00 GMT';

--- a/tests/Fake/fake-app/src/Resource/App/Dep/LevelOne.php
+++ b/tests/Fake/fake-app/src/Resource/App/Dep/LevelOne.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable
+ */
+#[Cacheable]
+class LevelOne extends ResourceObject
+{
+    public $body = ['level-one' => 1];
+
+    /**
+     * @Embed(rel="level-two", src="/dep/level-two")
+     */
+    #[Embed(src: '/dep/level-two', rel: 'two')]
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/App/Dep/LevelTwo.php
+++ b/tests/Fake/fake-app/src/Resource/App/Dep/LevelTwo.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class LevelTwo extends ResourceObject
+{
+    public $body = ['level-two' => 1];
+
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/LevelOne.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/LevelOne.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable
+ */
+#[Cacheable]
+class LevelOne extends ResourceObject
+{
+    public $body = ['level-one' => 1];
+
+    /**
+     * @Embed(rel="level-two", src="/dep/level-two")
+     */
+    #[Embed(rel: 'level-two', src: '/dep/level-two')]
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/LevelThree.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/LevelThree.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable
+ */
+#[Cacheable]
+class LevelThree extends ResourceObject
+{
+    public $body = ['level-three' => 1];
+
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/LevelTwo.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/LevelTwo.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+/**
+ * @Cacheable
+ */
+#[Cacheable]
+class LevelTwo extends ResourceObject
+{
+    public $body = ['level-two' => 1];
+
+    /**
+     * @Embed(rel="level-three", src="/dep/level-three")
+     */
+    #[Embed(rel: 'level-three', src: '/dep/level-three')]
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/ResourceRepositoryTest.php
+++ b/tests/ResourceRepositoryTest.php
@@ -30,7 +30,7 @@ class ResourceRepositoryTest extends TestCase
     protected function setUp(): void
     {
         $this->repository = new Repository(
-            new EtagSetter(),
+            new EtagSetter(new CacheDependency()),
             new ResourceStorage(
                 new FilesystemAdapter('', 0, $_ENV['TMP_DIR'])
             ),
@@ -102,7 +102,7 @@ class ResourceRepositoryTest extends TestCase
         };
         // phpcs:enable
         $repository = new Repository(
-            new EtagSetter(),
+            new EtagSetter(new CacheDependency()),
             new ResourceStorage(
                 null,
                 null,


### PR DESCRIPTION
Close #95 

Invalidate the cache and Etag of the parent resource when the "child resource" embedded in the parent resource has been modified.

This is made possible by the following technologies

* symfony/cache [TagAwareAdapter](https://symfony.com/doc/current/components/cache/cache_invalidation.html#tag-aware-adapters)

Embedで埋め込まれた子リソースに変更があった場合に、親リソースのキャッシュとEtagを無効にします。
