### PR TITLE
Fix refresh command issue on ResourceObject has an error code

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -41,6 +41,12 @@ jobs:
           coverage: pcov
           ini-values: zend.assertions=1
 
+      - name: Install pecl memcached
+        continue-on-error: true
+        run: |
+          sudo apt-get install -y libmemcached-dev
+          sudo pecl install memcached
+
       - name: Get composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "bamarni/composer-bin-plugin": "^1.4",
         "koriym/attributes": "^1.0.1",
         "madapaja/twig-module": "^2.3",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5.19",
         "psr/log": "^1.1",
         "ray/object-visual-grapher": "^1.0",
         "symfony/process": "^4.3",

--- a/src/CommandInterceptor.php
+++ b/src/CommandInterceptor.php
@@ -43,7 +43,7 @@ final class CommandInterceptor implements MethodInterceptor
         }
 
         if ($ro->code >= Code::BAD_REQUEST) {
-            return $this;
+            return $ro;
         }
 
         foreach ($this->commands as $command) {

--- a/src/CommandsProvider.php
+++ b/src/CommandsProvider.php
@@ -8,7 +8,7 @@ use BEAR\Resource\ResourceInterface;
 use Ray\Di\ProviderInterface;
 
 /**
- * @implements ProviderInterface<CommandInterface[]>
+ * @implements ProviderInterface<array<CommandInterface>>
  */
 final class CommandsProvider implements ProviderInterface
 {

--- a/src/CommandsProvider.php
+++ b/src/CommandsProvider.php
@@ -7,6 +7,9 @@ namespace BEAR\QueryRepository;
 use BEAR\Resource\ResourceInterface;
 use Ray\Di\ProviderInterface;
 
+/**
+ * @implements ProviderInterface<CommandInterface[]>
+ */
 final class CommandsProvider implements ProviderInterface
 {
     /** @var QueryRepositoryInterface */

--- a/src/DonutCommandInterceptor.php
+++ b/src/DonutCommandInterceptor.php
@@ -6,6 +6,7 @@ namespace BEAR\QueryRepository;
 
 use BEAR\QueryRepository\Exception\UnmatchedQuery;
 use BEAR\Resource\AbstractUri;
+use BEAR\Resource\Code;
 use BEAR\Resource\ResourceObject;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
@@ -36,6 +37,10 @@ final class DonutCommandInterceptor implements MethodInterceptor
     {
         $ro = $invocation->proceed();
         assert($ro instanceof ResourceObject);
+        if ($ro->code >= Code::BAD_REQUEST) {
+            return $ro;
+        }
+
         $this->refreshDonutAndState($ro);
 
         return $ro;

--- a/tests/DonutCommandInterceptorTest.php
+++ b/tests/DonutCommandInterceptorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository;
 
+use BEAR\Resource\Code;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Sunday\Extension\Transfer\HttpCacheInterface as HttpCacheInterfaceAlias;
 use Madapaja\TwigModule\TwigModule;
@@ -65,6 +66,21 @@ class DonutCommandInterceptorTest extends TestCase
         $this->assertFalse($this->httpCache->isNotModified($server));
         $this->logger->log('server:%s', $server);
         $this->logger->log('get');
+        $ro = $this->resource->get('page://self/html/blog-posting?id=0');
+        $this->assertArrayHasKey('Age', $ro->headers);
+    }
+
+    public function testCommandInterceptorRefreshOnErrorCode(): void
+    {
+        $this->resource->get('page://self/html/comment');
+        $ro = $this->resource->delete('page://self/html/comment');
+        $this->assertSame(Code::BAD_REQUEST, $ro->code);
+        $ro = $this->resource->get('page://self/html/comment');
+        $this->assertArrayHasKey('Age', $ro->headers);
+
+        $this->resource->get('page://self/html/blog-posting?id=0');
+        $ro = $this->resource->delete('page://self/html/blog-posting', ['id' => 9999]);
+        $this->assertSame(Code::BAD_REQUEST, $ro->code);
         $ro = $this->resource->get('page://self/html/blog-posting?id=0');
         $this->assertArrayHasKey('Age', $ro->headers);
     }

--- a/tests/Fake/fake-app/src/Resource/Page/Html/BlogPosting.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Html/BlogPosting.php
@@ -5,6 +5,7 @@ namespace FakeVendor\HelloWorld\Resource\Page\Html;
 use BEAR\QueryRepository\Header;
 use BEAR\RepositoryModule\Annotation\CacheableResponse;
 use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\Code;
 use BEAR\Resource\ResourceObject;
 use Koriym\HttpConstants\CacheControl;
 use Koriym\HttpConstants\ResponseHeader;
@@ -30,6 +31,12 @@ class BlogPosting extends ResourceObject
 
     public function onDelete(int $id = 0)
     {
+        if ($id !== 0) {
+            $this->code = Code::BAD_REQUEST;
+
+            return $this;
+        }
+
         return $this;
     }
 }

--- a/tests/Fake/fake-app/src/Resource/Page/Html/Comment.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Html/Comment.php
@@ -4,6 +4,7 @@ namespace FakeVendor\HelloWorld\Resource\Page\Html;
 
 use BEAR\RepositoryModule\Annotation\Cacheable;
 use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\Code;
 use BEAR\Resource\ResourceObject;
 
 /**
@@ -21,6 +22,13 @@ class Comment extends ResourceObject
         $this->body = [
             'comment' => 'comment01'
         ];
+
+        return $this;
+    }
+
+    public function onDelete()
+    {
+        $this->code = Code::BAD_REQUEST;
 
         return $this;
     }


### PR DESCRIPTION
* キャッシュをRefreshするResourceのリクエスト結果がエラーの場合に返却するオブジェクトが間違っていた問題を修正しました。
https://github.com/bearsunday/BEAR.QueryRepository/pull/108/files#diff-2c0c4b0b463b59f1c2d7143675b9abe0d7d8e848dbfc9109019e07f7bf7d2f56R46

* DonutCommandでも同様に、Refreshを行うResourceのリクエスト結果がエラーの場合は実行しないように変更しましたがどうでしょうか？
https://github.com/bearsunday/BEAR.QueryRepository/pull/108/files#diff-ae25b4220ad46573f47159c62506dda9dd3846009567b2a3c8100d2af492c4e7R41

* [落ちているCI](https://github.com/bearsunday/BEAR.QueryRepository/runs/5685832976?check_suite_focus=true)のエラーですが、
```
Symfony\Component\Cache\Exception\CacheException: Memcached > 3.1.5 is required.
```
3.1.6以降のpecl memcachedは3/24にリリースされた3.2.0しかなく、まだインストールできず・・・、何かいい方法ないでしょうか？