### PR TITLE
Changed to preserve Surrogate-Key held by ResourceObject at entry point

### DIFF
--- a/src/DonutRepository.php
+++ b/src/DonutRepository.php
@@ -61,6 +61,7 @@ final class DonutRepository implements DonutRepositoryInterface
     {
         $this->logger->log('put-donut: uri:%s ttl:%s s-maxage:%d', (string) $ro->uri, $sMaxAge, $ttl);
         $keys = new SurrogateKeys($ro->uri);
+        $keys->addTag($ro);
         $headerKeys = $this->getHeaderKeys($ro);
         $donut = ResourceDonut::create($ro, $this->renderer, $keys, $sMaxAge, true);
         $donut->render($ro, $this->renderer);

--- a/tests/DonutQueryInterceptorTest.php
+++ b/tests/DonutQueryInterceptorTest.php
@@ -88,8 +88,8 @@ invalidate-etag tags:_html_comment_
 save-etag uri:page://self/html/comment etag:_html_comment_ surrogate-keys:comment01 _html_comment_
 save-value uri:page://self/html/comment tags:_html_comment_ comment01 ttl:31536000
 invalidate-etag tags:_html_blog-posting_
-save-etag uri:page://self/html/blog-posting etag:_html_blog-posting_ surrogate-keys:_html_blog-posting_ _html_comment_ comment01
-save-donut-view uri:page://self/html/blog-posting surrogate-keys:_html_blog-posting_ _html_comment_ comment01 s-maxage:
+save-etag uri:page://self/html/blog-posting etag:_html_blog-posting_ surrogate-keys:_html_blog-posting_ blog-posting-page _html_comment_ comment01
+save-donut-view uri:page://self/html/blog-posting surrogate-keys:_html_blog-posting_ blog-posting-page _html_comment_ comment01 s-maxage:
 save-donut uri:page://self/html/blog-posting s-maxage:
 get
 try-donut-view: uri:page://self/html/blog-posting

--- a/tests/DonutQueryInterceptorTest.php
+++ b/tests/DonutQueryInterceptorTest.php
@@ -88,7 +88,7 @@ invalidate-etag tags:_html_comment_
 save-etag uri:page://self/html/comment etag:_html_comment_ surrogate-keys:comment01 _html_comment_
 save-value uri:page://self/html/comment tags:_html_comment_ comment01 ttl:31536000
 invalidate-etag tags:_html_blog-posting_
-save-etag uri:page://self/html/blog-posting etag:_html_blog-posting_ surrogate-keys:_html_blog-posting_ blog-posting-page _html_comment_ comment01
+save-etag uri:page://self/html/blog-posting etag:_html_blog-posting_ surrogate-keys:blog-posting-page _html_blog-posting_ _html_comment_ comment01
 save-donut-view uri:page://self/html/blog-posting surrogate-keys:_html_blog-posting_ blog-posting-page _html_comment_ comment01 s-maxage:
 save-donut uri:page://self/html/blog-posting s-maxage:
 get

--- a/tests/Fake/fake-app/src/Resource/Page/Html/BlogPosting.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Html/BlogPosting.php
@@ -25,6 +25,7 @@ class BlogPosting extends ResourceObject
         $this->body += [
             'article' => '1'
         ];
+        $this->headers[Header::SURROGATE_KEY] = 'blog-posting-page';
 
         return $this;
     }


### PR DESCRIPTION
* Pageリソースに直接設定されたSurrogate-Keyを保存するように変更しました。
* #118 の修正で、ResourceStorageにDonutを保存する際のタグとしては設定できていましたが、Surrogate-Key HTTPヘッダには出力できていない問題を修正しました。