### PR TITLE
Change RedisAdapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "ray/aop": "^2.10",
         "ray/di": "^2.13.1",
-        "ray/psr-cache-module": "^1.1.2",
+        "ray/psr-cache-module": "^1.3.2",
         "symfony/cache": "^5.3 || ^6.0",
         "symfony/cache-contracts": "^2.4 || ^3.0"
     },

--- a/src/StorageRedisModule.php
+++ b/src/StorageRedisModule.php
@@ -8,8 +8,6 @@ use BEAR\RepositoryModule\Annotation\EtagPool;
 use Psr\Cache\CacheItemPoolInterface;
 use Ray\Di\AbstractModule;
 use Ray\PsrCacheModule\Annotation\CacheNamespace;
-use Ray\PsrCacheModule\Annotation\RedisInstance;
-use Ray\PsrCacheModule\Annotation\Shared;
 use Ray\PsrCacheModule\Psr6RedisModule;
 use Ray\PsrCacheModule\RedisAdapter;
 

--- a/src/StorageRedisModule.php
+++ b/src/StorageRedisModule.php
@@ -9,8 +9,9 @@ use Psr\Cache\CacheItemPoolInterface;
 use Ray\Di\AbstractModule;
 use Ray\PsrCacheModule\Annotation\CacheNamespace;
 use Ray\PsrCacheModule\Annotation\RedisInstance;
+use Ray\PsrCacheModule\Annotation\Shared;
 use Ray\PsrCacheModule\Psr6RedisModule;
-use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Ray\PsrCacheModule\RedisAdapter;
 
 /**
  * Provides ResourceStorageInterface and derived bindings
@@ -40,7 +41,7 @@ final class StorageRedisModule extends AbstractModule
     {
         $this->install(new Psr6RedisModule($this->server));
         $this->bind(CacheItemPoolInterface::class)->annotatedWith(EtagPool::class)->toConstructor(RedisAdapter::class, [
-            'redis' => RedisInstance::class,
+            'redisProvider' => 'redis',
             'namespace' => CacheNamespace::class,
         ]);
     }


### PR DESCRIPTION
Symfony to Ray\PsrCacheModule

EtagPoolのキャッシュの束縛をシリアライズ不可能なSymfonyのRedisアダプターから、シリアライズ可能なRay\PsrCacheModuleのRedisAdapterにします。