### PR TITLE
Add ResourceDonut header to save headers

### DIFF
--- a/src/ResourceDonut.php
+++ b/src/ResourceDonut.php
@@ -22,8 +22,10 @@ final class ResourceDonut
 
     private const URI_REGEX = '/\[le:(.+)]/';
 
+    /** @param array<string, string> $headers */
     public function __construct(
         private string $template,
+        private array $headers,
         /** @readonly */
         public int|null $ttl,
         /** @readonly */
@@ -45,8 +47,9 @@ final class ResourceDonut
             return (string) $ro->view;
         }, $this->template);
 
-        $etags->setSurrogateHeader($ro);
+        $ro->headers = $this->headers;
         $ro->view = $refreshView;
+        $etags->setSurrogateHeader($ro);
 
         return $ro;
     }
@@ -72,6 +75,6 @@ final class ResourceDonut
         unset($maybeRequest);
         $donutTemplate = (string) $ro;
 
-        return new self($donutTemplate, $ttl, $isCacheble);
+        return new self($donutTemplate, $ro->headers, $ttl, $isCacheble);
     }
 }

--- a/src/ResourceStorageSaver.php
+++ b/src/ResourceStorageSaver.php
@@ -19,7 +19,7 @@ final class ResourceStorageSaver
         assert($cacheItem instanceof CacheItem);
         $cacheItem->tag($tags);
 
-        if ($ttl) {
+        if ($ttl !== null && $ttl > 0) {
             $cacheItem->expiresAfter($ttl);
         }
 

--- a/tests/DonutCacheTest.php
+++ b/tests/DonutCacheTest.php
@@ -30,10 +30,12 @@ class DonutCacheTest extends TestCase
 
     public function testGetState(): void
     {
-        $donut = new ResourceDonut('cmt=[le:page://self/html/comment]', null, true);
+        $headers = ['Content-Type' => 'application/xml;'];
+        $donut = new ResourceDonut('cmt=[le:page://self/html/comment]', $headers, null, true);
         $blog = $this->resource->get('page://self/html/blog-posting');
         $ro = $donut->refresh($this->resource, $blog);
         $this->assertInstanceOf(ResourceObject::class, $ro);
         $this->assertSame('cmt=comment01', $ro->view);
+        $this->assertSame($headers['Content-Type'], $ro->headers['Content-Type']);
     }
 }

--- a/tests/DonutRepositoryTest.php
+++ b/tests/DonutRepositoryTest.php
@@ -116,6 +116,7 @@ class DonutRepositoryTest extends TestCase
         assert($queryRepository->purge(new Uri('page://self/html/comment')));
         $donutRo = $resource->get('page://self/html/blog-posting');
         $this->assertSame('r', $donutRo->headers[Header::ETAG][-1]);
+        $this->assertStringContainsString('blog-posting-page', $donutRo->headers[Header::SURROGATE_KEY]);
     }
 
     public function testInvalidateTags(): void


### PR DESCRIPTION
`ResouceDonut` がヘッダーを保持しておらず、リフレッシュするとDonut自体に設定されているヘッダーが失われてしまう問題を修正しました。