### PR TITLE
Windows: Normalize URI separators in cache key generation

### DIFF
--- a/src/UriTag.php
+++ b/src/UriTag.php
@@ -26,7 +26,7 @@ final class UriTag implements UriTagInterface
         $query = $uri->query;
         ksort($query);
 
-        return str_replace(DIRECTORY_SEPARATOR, '_', sprintf('%s_%s', $uri->path, http_build_query($query)));
+        return str_replace([DIRECTORY_SEPARATOR, '/'], '_', sprintf('%s_%s', $uri->path, http_build_query($query)));
     }
 
     /**


### PR DESCRIPTION
**Description:**
This pull request normalizes URI separators in cache key generation. Previously, only directory separators were replaced with underscores. With this update, both `DIRECTORY_SEPARATOR` and forward slashes are normalized, ensuring consistency in cache key generation.