### PR TITLE
Document cache attributes and interceptors

### DIFF
--- a/src-annotation/Cacheable.php
+++ b/src-annotation/Cacheable.php
@@ -7,7 +7,11 @@ namespace BEAR\RepositoryModule\Annotation;
 use Attribute;
 
 /**
- * Marks a resource class as cacheable with TTL-based caching
+ * Marks a resource class as cacheable with TTL-based expiration
+ *
+ * Traditional time-based caching where cache expires after a specified duration.
+ * For event-driven cache invalidation based on resource dependencies, use
+ * #[CacheableResponse] or #[DonutCache] instead.
  *
  * Interceptors bound:
  * - CacheInterceptor (onGet methods)

--- a/src-annotation/Cacheable.php
+++ b/src-annotation/Cacheable.php
@@ -6,6 +6,15 @@ namespace BEAR\RepositoryModule\Annotation;
 
 use Attribute;
 
+/**
+ * Marks a resource class as cacheable with TTL-based caching
+ *
+ * Interceptors bound:
+ * - CacheInterceptor (onGet methods)
+ * - CommandInterceptor (onPut/onPatch/onDelete methods)
+ *
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#cacheable
+ */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class Cacheable
 {

--- a/src-annotation/Cacheable.php
+++ b/src-annotation/Cacheable.php
@@ -13,6 +13,18 @@ use Attribute;
  * For event-driven cache invalidation based on resource dependencies, use
  * #[CacheableResponse] or #[DonutCache] instead.
  *
+ * Example:
+ * ```php
+ * // Cache for 1 hour
+ * #[Cacheable(expirySecond: 3600)]
+ *
+ * // Cache with predefined expiry preset
+ * #[Cacheable(expiry: 'short')]  // short, medium, long, never
+ *
+ * // Cache until specific time from body field
+ * #[Cacheable(expiryAt: 'expires_at')]
+ * ```
+ *
  * Interceptors bound:
  * - CacheInterceptor (onGet methods)
  * - CommandInterceptor (onPut/onPatch/onDelete methods)

--- a/src-annotation/CacheableResponse.php
+++ b/src-annotation/CacheableResponse.php
@@ -22,9 +22,15 @@ use BEAR\QueryRepository\DonutCacheModule;
  * class Article extends ResourceObject
  * {
  *     public function onGet(int $id): static
+ *     {
+ *         // ...
+ *     }
  *
  *     #[RefreshCache]
  *     public function onDelete(int $id): static
+ *     {
+ *         // ...
+ *     }
  * }
  * ```
  *

--- a/src-annotation/CacheableResponse.php
+++ b/src-annotation/CacheableResponse.php
@@ -16,6 +16,18 @@ use BEAR\QueryRepository\DonutCacheModule;
  * The entire response is cached and receives an ETag for conditional requests,
  * enabling 304 (Not Modified) responses to reduce network transfer costs.
  *
+ * Example:
+ * ```php
+ * #[CacheableResponse]
+ * class Article extends ResourceObject
+ * {
+ *     public function onGet(int $id): static
+ *
+ *     #[RefreshCache]
+ *     public function onDelete(int $id): static
+ * }
+ * ```
+ *
  * Interceptors bound:
  * - DonutCacheableResponseInterceptor (onGet methods when applied to class)
  * - DonutCommandInterceptor (onPut/onPatch/onDelete methods when applied to class)

--- a/src-annotation/CacheableResponse.php
+++ b/src-annotation/CacheableResponse.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace BEAR\RepositoryModule\Annotation;
 
 use Attribute;
-use BEAR\QueryRepository\DonutCacheableResponseInterceptor;
 use BEAR\QueryRepository\DonutCacheModule;
-use BEAR\QueryRepository\DonutCommandInterceptor;
 
 /**
- * Marks a resource for full response caching (entire content is cacheable)
+ * Enables event-driven cache invalidation for fully cacheable responses
+ *
+ * For content that is fundamentally static but changes predictably via resource
+ * methods (onPut, onDelete, etc.). Unlike #[Cacheable] which uses TTL-based
+ * expiration, this enables tag-based invalidation driven by resource dependencies.
+ * The entire response is cached and receives an ETag for conditional requests,
+ * enabling 304 (Not Modified) responses to reduce network transfer costs.
  *
  * Interceptors bound:
  * - DonutCacheableResponseInterceptor (onGet methods when applied to class)
@@ -18,7 +22,7 @@ use BEAR\QueryRepository\DonutCommandInterceptor;
  * - DonutCacheInterceptor (when applied to method)
  *
  * @see DonutCacheModule
- * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#donut-cache
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#event-driven-content
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 final class CacheableResponse

--- a/src-annotation/CacheableResponse.php
+++ b/src-annotation/CacheableResponse.php
@@ -10,9 +10,15 @@ use BEAR\QueryRepository\DonutCacheModule;
 use BEAR\QueryRepository\DonutCommandInterceptor;
 
 /**
+ * Marks a resource for full response caching (entire content is cacheable)
+ *
+ * Interceptors bound:
+ * - DonutCacheableResponseInterceptor (onGet methods when applied to class)
+ * - DonutCommandInterceptor (onPut/onPatch/onDelete methods when applied to class)
+ * - DonutCacheInterceptor (when applied to method)
+ *
  * @see DonutCacheModule
- * @see DonutCacheableResponseInterceptor
- * @see DonutCommandInterceptor
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#donut-cache
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 final class CacheableResponse

--- a/src-annotation/DonutCache.php
+++ b/src-annotation/DonutCache.php
@@ -22,6 +22,9 @@ use BEAR\QueryRepository\DonutCacheModule;
  * {
  *     #[Embed(rel: 'comment', src: 'app://self/comments')]
  *     public function onGet(int $id): static
+ *     {
+ *         // ...
+ *     }
  * }
  * ```
  *

--- a/src-annotation/DonutCache.php
+++ b/src-annotation/DonutCache.php
@@ -15,6 +15,16 @@ use BEAR\QueryRepository\DonutCacheModule;
  * which uses TTL-based expiration, this enables tag-based invalidation. Only
  * cacheable portions are stored; no ETag is generated for the entire response.
  *
+ * Example:
+ * ```php
+ * #[DonutCache]
+ * class BlogPosting extends ResourceObject
+ * {
+ *     #[Embed(rel: 'comment', src: 'app://self/comments')]
+ *     public function onGet(int $id): static
+ * }
+ * ```
+ *
  * Interceptors bound:
  * - DonutCacheInterceptor (onGet methods when applied to class, or any method when applied to method)
  *

--- a/src-annotation/DonutCache.php
+++ b/src-annotation/DonutCache.php
@@ -9,9 +9,13 @@ use BEAR\QueryRepository\DonutCacheModule;
 use BEAR\QueryRepository\DonutCommandInterceptor;
 
 /**
+ * Marks a resource for donut caching (partial caching with embedded dynamic content)
+ *
+ * Interceptors bound:
+ * - DonutCacheInterceptor (onGet methods when applied to class, or any method when applied to method)
+ *
  * @see DonutCacheModule
- * @see DonutCacheInterceptor
- * @see DonutCommandInterceptor
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#donut-cache
  */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
 final class DonutCache

--- a/src-annotation/DonutCache.php
+++ b/src-annotation/DonutCache.php
@@ -6,10 +6,14 @@ namespace BEAR\RepositoryModule\Annotation;
 
 use Attribute;
 use BEAR\QueryRepository\DonutCacheModule;
-use BEAR\QueryRepository\DonutCommandInterceptor;
 
 /**
- * Marks a resource for donut caching (partial caching with embedded dynamic content)
+ * Enables event-driven donut caching for resources with non-cacheable embedded content
+ *
+ * For content that is fundamentally static but changes predictably via resource
+ * methods, with some embedded resources that cannot be cached. Unlike #[Cacheable]
+ * which uses TTL-based expiration, this enables tag-based invalidation. Only
+ * cacheable portions are stored; no ETag is generated for the entire response.
  *
  * Interceptors bound:
  * - DonutCacheInterceptor (onGet methods when applied to class, or any method when applied to method)

--- a/src-annotation/HttpCache.php
+++ b/src-annotation/HttpCache.php
@@ -17,13 +17,19 @@ use function sprintf;
  *
  * Example:
  * ```php
+ * // Cache for 1 hour
+ * #[HttpCache(maxAge: 3600)]
+ *
+ * // Cache with revalidation when stale
+ * #[HttpCache(maxAge: 3600, mustRevalidate: true)]
+ *
+ * // Private cache (not shared cache like CDN)
+ * #[HttpCache(isPrivate: true, maxAge: 300)]
+ *
  * // CDN cache for 1 hour, browser cache for 5 minutes
  * #[HttpCache(maxAge: 300, sMaxAge: 3600)]
  *
- * // Private cache with revalidation
- * #[HttpCache(isPrivate: true, mustRevalidate: true, maxAge: 60)]
- *
- * // For no caching, use #[NoHttpCache] instead
+ * // For disabling cache, use #[NoHttpCache] instead
  * ```
  *
  * Interceptors bound:

--- a/src-annotation/HttpCache.php
+++ b/src-annotation/HttpCache.php
@@ -15,7 +15,11 @@ use function sprintf;
  *
  * Builds a complex Cache-Control header
  *
+ * Interceptors bound:
+ * - HttpCacheInterceptor (onGet methods)
+ *
  * @see HttpCacheInterceptor
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class HttpCache extends AbstractCacheControl

--- a/src-annotation/HttpCache.php
+++ b/src-annotation/HttpCache.php
@@ -15,6 +15,18 @@ use function sprintf;
  *
  * Builds a complex Cache-Control header
  *
+ * Example:
+ * ```php
+ * // CDN cache for 1 hour, browser cache for 5 minutes
+ * #[HttpCache(maxAge: 300, sMaxAge: 3600)]
+ *
+ * // Private cache with revalidation
+ * #[HttpCache(isPrivate: true, mustRevalidate: true, maxAge: 60)]
+ *
+ * // No caching (use NoHttpCache instead for simplicity)
+ * #[HttpCache(noCache: true, noStore: true)]
+ * ```
+ *
  * Interceptors bound:
  * - HttpCacheInterceptor (onGet methods)
  *

--- a/src-annotation/HttpCache.php
+++ b/src-annotation/HttpCache.php
@@ -23,8 +23,7 @@ use function sprintf;
  * // Private cache with revalidation
  * #[HttpCache(isPrivate: true, mustRevalidate: true, maxAge: 60)]
  *
- * // No caching (use NoHttpCache instead for simplicity)
- * #[HttpCache(noCache: true, noStore: true)]
+ * // For no caching, use #[NoHttpCache] instead
  * ```
  *
  * Interceptors bound:

--- a/src-annotation/NoHttpCache.php
+++ b/src-annotation/NoHttpCache.php
@@ -12,7 +12,11 @@ use BEAR\QueryRepository\HttpCacheInterceptor;
  *
  * Simplified notation to say that you don't want anything cached
  *
+ * Interceptors bound:
+ * - HttpCacheInterceptor (onGet methods)
+ *
  * @see HttpCacheInterceptor
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html
  */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class NoHttpCache extends AbstractCacheControl

--- a/src-annotation/Purge.php
+++ b/src-annotation/Purge.php
@@ -6,7 +6,15 @@ namespace BEAR\RepositoryModule\Annotation;
 
 use Attribute;
 
-/** @see RefreshInterceptor */
+/**
+ * Purges cache for specified URI after command execution
+ *
+ * Interceptors bound:
+ * - RefreshInterceptor (when applied to non-Cacheable classes)
+ * - CommandInterceptor (when applied to Cacheable classes)
+ *
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#tag-based-cache-invalidation
+ */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Purge extends AbstractCommand
 {

--- a/src-annotation/Purge.php
+++ b/src-annotation/Purge.php
@@ -9,16 +9,18 @@ use Attribute;
 /**
  * Purges cache for specified URI after command execution
  *
+ * Behavior differs based on class attributes:
+ * - **#[Cacheable] classes**: CommandInterceptor automatically binds to all
+ *   command methods (onPut/onPatch/onDelete) and processes #[Purge] annotations
+ * - **Non-Cacheable classes**: RefreshInterceptor binds only to methods explicitly
+ *   marked with #[Purge] or #[Refresh]
+ *
  * Example:
  * ```php
  * #[Purge(uri: 'app://self/user/profile?user_id={id}')]
  * #[Purge(uri: 'app://self/user/friend?user_id={id}')]
  * public function onDelete(int $id): static
  * ```
- *
- * Interceptors bound:
- * - RefreshInterceptor (when applied to non-Cacheable classes)
- * - CommandInterceptor (when applied to Cacheable classes)
  *
  * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#tag-based-cache-invalidation
  */

--- a/src-annotation/Purge.php
+++ b/src-annotation/Purge.php
@@ -9,6 +9,13 @@ use Attribute;
 /**
  * Purges cache for specified URI after command execution
  *
+ * Example:
+ * ```php
+ * #[Purge(uri: 'app://self/user/profile?user_id={id}')]
+ * #[Purge(uri: 'app://self/user/friend?user_id={id}')]
+ * public function onDelete(int $id): static
+ * ```
+ *
  * Interceptors bound:
  * - RefreshInterceptor (when applied to non-Cacheable classes)
  * - CommandInterceptor (when applied to Cacheable classes)

--- a/src-annotation/Purge.php
+++ b/src-annotation/Purge.php
@@ -20,6 +20,9 @@ use Attribute;
  * #[Purge(uri: 'app://self/user/profile?user_id={id}')]
  * #[Purge(uri: 'app://self/user/friend?user_id={id}')]
  * public function onDelete(int $id): static
+ * {
+ *     // ...
+ * }
  * ```
  *
  * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#tag-based-cache-invalidation

--- a/src-annotation/Refresh.php
+++ b/src-annotation/Refresh.php
@@ -19,6 +19,9 @@ use Attribute;
  * ```php
  * #[Refresh(uri: 'app://self/user/profile?user_id={id}')]
  * public function onPut(int $id, string $name): static
+ * {
+ *     // ...
+ * }
  * ```
  *
  * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#event-driven-content

--- a/src-annotation/Refresh.php
+++ b/src-annotation/Refresh.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\RepositoryModule\Annotation;
 
 use Attribute;
-use BEAR\QueryRepository\RefreshInterceptor;
 
 /**
  * Refreshes cache for specified URI after command execution

--- a/src-annotation/Refresh.php
+++ b/src-annotation/Refresh.php
@@ -9,6 +9,12 @@ use Attribute;
 /**
  * Refreshes cache for specified URI after command execution
  *
+ * Example:
+ * ```php
+ * #[Refresh(uri: 'app://self/user/profile?user_id={id}')]
+ * public function onPut(int $id, string $name): static
+ * ```
+ *
  * Interceptors bound:
  * - RefreshInterceptor (when applied to non-Cacheable classes)
  * - CommandInterceptor (when applied to Cacheable classes)

--- a/src-annotation/Refresh.php
+++ b/src-annotation/Refresh.php
@@ -7,7 +7,15 @@ namespace BEAR\RepositoryModule\Annotation;
 use Attribute;
 use BEAR\QueryRepository\RefreshInterceptor;
 
-/** @see RefreshInterceptor */
+/**
+ * Refreshes cache for specified URI after command execution
+ *
+ * Interceptors bound:
+ * - RefreshInterceptor (when applied to non-Cacheable classes)
+ * - CommandInterceptor (when applied to Cacheable classes)
+ *
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#event-driven-content
+ */
 #[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Refresh extends AbstractCommand
 {

--- a/src-annotation/Refresh.php
+++ b/src-annotation/Refresh.php
@@ -9,15 +9,17 @@ use Attribute;
 /**
  * Refreshes cache for specified URI after command execution
  *
+ * Behavior differs based on class attributes:
+ * - **#[Cacheable] classes**: CommandInterceptor automatically binds to all
+ *   command methods (onPut/onPatch/onDelete) and processes #[Refresh] annotations
+ * - **Non-Cacheable classes**: RefreshInterceptor binds only to methods explicitly
+ *   marked with #[Purge] or #[Refresh]
+ *
  * Example:
  * ```php
  * #[Refresh(uri: 'app://self/user/profile?user_id={id}')]
  * public function onPut(int $id, string $name): static
  * ```
- *
- * Interceptors bound:
- * - RefreshInterceptor (when applied to non-Cacheable classes)
- * - CommandInterceptor (when applied to Cacheable classes)
  *
  * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#event-driven-content
  */

--- a/src-annotation/RefreshCache.php
+++ b/src-annotation/RefreshCache.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\RepositoryModule\Annotation;
 
 use Attribute;
-use BEAR\QueryRepository\DonutCommandInterceptor;
 
 /**
  * Refreshes donut cache after command execution

--- a/src-annotation/RefreshCache.php
+++ b/src-annotation/RefreshCache.php
@@ -7,7 +7,14 @@ namespace BEAR\RepositoryModule\Annotation;
 use Attribute;
 use BEAR\QueryRepository\DonutCommandInterceptor;
 
-/** @see DonutCommandInterceptor */
+/**
+ * Refreshes donut cache after command execution
+ *
+ * Interceptors bound:
+ * - DonutCacheInterceptor
+ *
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#cache-invalidation
+ */
 #[Attribute(Attribute::TARGET_METHOD)]
 final class RefreshCache
 {

--- a/src/CacheInterceptor.php
+++ b/src/CacheInterceptor.php
@@ -17,6 +17,16 @@ use function trigger_error;
 
 use const E_USER_WARNING;
 
+/**
+ * Interceptor for TTL-based caching on CQRS queries with #[Cacheable]
+ *
+ * Bound to query methods (onGet) of classes marked with #[Cacheable].
+ * Retrieves cached resource state if available, otherwise executes
+ * the method and stores the result with configured TTL.
+ *
+ * @see \BEAR\RepositoryModule\Annotation\Cacheable
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#cacheable
+ */
 final readonly class CacheInterceptor implements MethodInterceptor
 {
     public function __construct(

--- a/src/CommandInterceptor.php
+++ b/src/CommandInterceptor.php
@@ -12,6 +12,16 @@ use Override;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 
+/**
+ * Interceptor for cache invalidation on CQRS commands with #[Purge] or #[Refresh]
+ *
+ * Bound to command methods (onPut/onPatch/onDelete) of #[Cacheable] classes.
+ * Executes cache invalidation after successful write operations.
+ *
+ * @see \BEAR\RepositoryModule\Annotation\Purge
+ * @see \BEAR\RepositoryModule\Annotation\Refresh
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#tag-based-cache-invalidation
+ */
 final readonly class CommandInterceptor implements MethodInterceptor
 {
     /** @param CommandInterface[] $commands */

--- a/src/CommandInterceptor.php
+++ b/src/CommandInterceptor.php
@@ -15,8 +15,12 @@ use Ray\Aop\MethodInvocation;
 /**
  * Interceptor for cache invalidation on CQRS commands with #[Purge] or #[Refresh]
  *
- * Bound to command methods (onPut/onPatch/onDelete) of #[Cacheable] classes.
- * Executes cache invalidation after successful write operations.
+ * Automatically bound to all command methods (onPut/onPatch/onDelete) of #[Cacheable] classes.
+ * Processes #[Purge] and #[Refresh] annotations on these methods and executes cache
+ * invalidation after successful write operations.
+ *
+ * For non-Cacheable classes, use RefreshInterceptor instead by explicitly marking methods
+ * with #[Purge] or #[Refresh].
  *
  * @see \BEAR\RepositoryModule\Annotation\Purge
  * @see \BEAR\RepositoryModule\Annotation\Refresh

--- a/src/DonutCacheInterceptor.php
+++ b/src/DonutCacheInterceptor.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository;
 
+/**
+ * Interceptor for donut caching on CQRS queries with #[DonutCache]
+ *
+ * Bound to query methods (onGet) or individual methods marked with #[DonutCache].
+ * Caches only the cacheable portions, excluding non-cacheable embedded content.
+ * No ETag is generated for the entire response.
+ *
+ * @see \BEAR\RepositoryModule\Annotation\DonutCache
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#donut-cache
+ */
 final class DonutCacheInterceptor extends AbstractDonutCacheInterceptor
 {
     protected const IS_ENTIRE_CONTENT_CACHEABLE = false;

--- a/src/DonutCacheableResponseInterceptor.php
+++ b/src/DonutCacheableResponseInterceptor.php
@@ -4,6 +4,16 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository;
 
+/**
+ * Interceptor for full response caching on CQRS queries with #[CacheableResponse]
+ *
+ * Bound to query methods (onGet) of classes marked with #[CacheableResponse].
+ * Caches the entire response and generates an ETag for conditional requests.
+ * Enables 304 (Not Modified) responses for efficient network transfer.
+ *
+ * @see \BEAR\RepositoryModule\Annotation\CacheableResponse
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#event-driven-content
+ */
 final class DonutCacheableResponseInterceptor extends AbstractDonutCacheInterceptor
 {
     protected const IS_ENTIRE_CONTENT_CACHEABLE = true;

--- a/src/DonutCommandInterceptor.php
+++ b/src/DonutCommandInterceptor.php
@@ -19,6 +19,16 @@ use function get_class;
 use function is_callable;
 use function sprintf;
 
+/**
+ * Interceptor for donut cache invalidation on CQRS commands
+ *
+ * Bound to command methods (onPut/onPatch/onDelete) of classes marked with #[CacheableResponse].
+ * Refreshes donut cache and resource state after successful write operations.
+ *
+ * @see \BEAR\RepositoryModule\Annotation\CacheableResponse
+ * @see \BEAR\RepositoryModule\Annotation\DonutCache
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#event-driven-content
+ */
 final readonly class DonutCommandInterceptor implements MethodInterceptor
 {
     public function __construct(

--- a/src/HttpCacheInterceptor.php
+++ b/src/HttpCacheInterceptor.php
@@ -14,6 +14,16 @@ use Ray\Aop\MethodInvocation;
 
 use function assert;
 
+/**
+ * Interceptor for HTTP Cache-Control header with #[HttpCache] or #[NoHttpCache]
+ *
+ * Bound to onGet methods of classes marked with #[HttpCache] or #[NoHttpCache].
+ * Sets the Cache-Control header based on attribute configuration for HTTP caching.
+ *
+ * @see \BEAR\RepositoryModule\Annotation\HttpCache
+ * @see \BEAR\RepositoryModule\Annotation\NoHttpCache
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html
+ */
 final class HttpCacheInterceptor implements MethodInterceptor
 {
     /**

--- a/src/RefreshInterceptor.php
+++ b/src/RefreshInterceptor.php
@@ -14,7 +14,10 @@ use Ray\Aop\MethodInvocation;
 /**
  * Interceptor for cache refresh commands with #[Purge] or #[Refresh]
  *
- * Bound to methods marked with #[Purge] or #[Refresh] on non-Cacheable classes.
+ * Bound only to methods explicitly marked with #[Purge] or #[Refresh] on non-Cacheable classes.
+ * Unlike CommandInterceptor (which automatically binds to all command methods of #[Cacheable]
+ * classes), this interceptor requires explicit attribute annotation on each method.
+ *
  * Executes cache invalidation commands after successful method execution.
  *
  * @see \BEAR\RepositoryModule\Annotation\Purge

--- a/src/RefreshInterceptor.php
+++ b/src/RefreshInterceptor.php
@@ -11,6 +11,16 @@ use Override;
 use Ray\Aop\MethodInterceptor;
 use Ray\Aop\MethodInvocation;
 
+/**
+ * Interceptor for cache refresh commands with #[Purge] or #[Refresh]
+ *
+ * Bound to methods marked with #[Purge] or #[Refresh] on non-Cacheable classes.
+ * Executes cache invalidation commands after successful method execution.
+ *
+ * @see \BEAR\RepositoryModule\Annotation\Purge
+ * @see \BEAR\RepositoryModule\Annotation\Refresh
+ * @see https://bearsunday.github.io/manuals/1.0/en/cache.html#event-driven-content
+ */
 final readonly class RefreshInterceptor implements MethodInterceptor
 {
     public function __construct(


### PR DESCRIPTION
## Summary
- Add comprehensive documentation to cache attributes
- Add docblocks to interceptor classes
- Include usage examples and interceptor binding information
- Clarify Event-Driven Content concepts

## Changes

### Cache Attributes Documentation

**#[Cacheable]** - TTL-based caching
- Add usage examples (expirySecond, expiry presets, expiryAt)
- Document bound interceptors (CacheInterceptor, CommandInterceptor)
- Link to manual section

**#[HttpCache]** - HTTP Cache-Control header
- Add examples from basic to advanced (maxAge, mustRevalidate, isPrivate, sMaxAge)
- Remove misleading no-cache/no-store example
- Encourage use of #[NoHttpCache] for disabling cache

**#[NoHttpCache]** - Disable HTTP caching
- Add interceptor binding information
- Link to manual

**#[CacheableResponse]** - Event-driven full response caching
- Explain fundamentally static content with predictable changes
- Highlight ETag and 304 (Not Modified) benefits
- Add usage example with RefreshCache
- Document bound interceptors

**#[DonutCache]** - Event-driven donut caching
- Explain use case for non-cacheable embedded content
- Add usage example with Embed
- Clarify no ETag generation

**#[Purge]** / **#[Refresh]** - Cache invalidation
- Add usage examples with URI templates
- Document bound interceptors (RefreshInterceptor, CommandInterceptor)

**#[RefreshCache]** - Donut cache refresh
- Document bound interceptor (DonutCacheInterceptor)

### Interceptor Classes Documentation

**CacheInterceptor** - TTL-based caching on CQRS queries
**CommandInterceptor** - Cache invalidation on CQRS commands
**HttpCacheInterceptor** - HTTP Cache-Control header
**DonutCacheInterceptor** - Donut caching on CQRS queries
**DonutCacheableResponseInterceptor** - Full response caching on CQRS queries
**DonutCommandInterceptor** - Donut cache invalidation on CQRS commands
**RefreshInterceptor** - Cache refresh for non-Cacheable classes

All interceptors now include:
- Clear description of purpose
- Which attributes they bind to
- CQRS query vs command distinction
- Links to attribute classes and manual sections

## Benefits
- Developers can understand interceptor binding without reading module code
- Usage examples provide quick reference
- Clear distinction between TTL-based and event-driven caching
- Better understanding of CQRS pattern in caching system

## Summary by Sourcery

Document cache annotations and interceptor classes with detailed docblocks, usage examples, binding information, and links to the manual

Enhancements:
- Add comprehensive docblocks to cache annotation classes with usage examples, interceptor binding details, and manual links
- Add detailed documentation to interceptor classes describing their purpose, attribute bindings, and CQRS context

Documentation:
- Clarify event-driven content concepts and distinctions between TTL-based and HTTP caching modes in the documentation