### PR TITLE
Add ServerContextInterface for coroutine-safe request handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.15.0] - 2026-02-03
+
+### Added
+- Add `ServerContextInterface` for coroutine-safe request handling in Swoole/RoadRunner environments
+- Add `GlobalServerContext` as default implementation using `$_SERVER` superglobal
+- Add `RepositoryLoggerInterface` with `reset()` method for long-running process support
+
+### Changed
+- Bind `ServerContextInterface` to `GlobalServerContext` in `QueryRepositoryModule`
+- Use `ServerContextInterface` in `ResourceStorage` instead of direct `$_SERVER` access
+
 ## [1.14.0] - 2025-01-24
 
 ### Added


### PR DESCRIPTION
## Summary
- Add `ServerContextInterface` and `GlobalServerContext` to abstract `$_SERVER` access for coroutine-safe environments (Swoole, RoadRunner, ReactPHP)
- Add `RepositoryLoggerInterface` with `reset()` for long-running process support
- Bind `ServerContextInterface` in `QueryRepositoryModule`, use it in `ResourceStorage`

## Test plan
- [x] Unit tests for `GlobalServerContext`
- [x] Unit tests for `RepositoryLogger`
- [x] All existing tests pass
- [x] PHPStan / Psalm clean