### PR TITLE
Replace deprecated DateTimeInterface::RFC7231 with literal format string

### DIFF
--- a/src/DevEtagSetter.php
+++ b/src/DevEtagSetter.php
@@ -29,7 +29,7 @@ final readonly class DevEtagSetter implements EtagSetterInterface
         // This is useful for debugging purposes.
         // Usually, the ETag is a hash of the resource view or body.
         $ro->headers[Header::ETAG] = $uriEtag;
-        $ro->headers[Header::LAST_MODIFIED] = gmdate('D, d M Y H:i:s \G\M\T', 0);
+        $ro->headers[Header::LAST_MODIFIED] = gmdate(Header::RFC7231, 0);
         $this->setCacheDependency($ro);
     }
 

--- a/src/DevEtagSetter.php
+++ b/src/DevEtagSetter.php
@@ -7,7 +7,6 @@ namespace BEAR\QueryRepository;
 use BEAR\RepositoryModule\Annotation\HttpCache;
 use BEAR\Resource\Request;
 use BEAR\Resource\ResourceObject;
-use DateTimeInterface;
 use Override;
 
 use function gmdate;
@@ -30,7 +29,7 @@ final readonly class DevEtagSetter implements EtagSetterInterface
         // This is useful for debugging purposes.
         // Usually, the ETag is a hash of the resource view or body.
         $ro->headers[Header::ETAG] = $uriEtag;
-        $ro->headers[Header::LAST_MODIFIED] = gmdate(DateTimeInterface::RFC7231, 0);
+        $ro->headers[Header::LAST_MODIFIED] = gmdate('D, d M Y H:i:s \G\M\T', 0);
         $this->setCacheDependency($ro);
     }
 

--- a/src/EtagSetter.php
+++ b/src/EtagSetter.php
@@ -7,7 +7,6 @@ namespace BEAR\QueryRepository;
 use BEAR\RepositoryModule\Annotation\HttpCache;
 use BEAR\Resource\Request;
 use BEAR\Resource\ResourceObject;
-use DateTimeInterface;
 use Override;
 
 use function assert;
@@ -38,7 +37,7 @@ final readonly class EtagSetter implements EtagSetterInterface
 
         $etag =  $this->getEtag($ro, $httpCache);
         $ro->headers[Header::ETAG] = $etag;
-        $ro->headers[Header::LAST_MODIFIED] = gmdate(DateTimeInterface::RFC7231, $time);
+        $ro->headers[Header::LAST_MODIFIED] = gmdate('D, d M Y H:i:s \G\M\T', $time);
         $this->setCacheDependency($ro);
     }
 

--- a/src/EtagSetter.php
+++ b/src/EtagSetter.php
@@ -37,7 +37,7 @@ final readonly class EtagSetter implements EtagSetterInterface
 
         $etag =  $this->getEtag($ro, $httpCache);
         $ro->headers[Header::ETAG] = $etag;
-        $ro->headers[Header::LAST_MODIFIED] = gmdate('D, d M Y H:i:s \G\M\T', $time);
+        $ro->headers[Header::LAST_MODIFIED] = gmdate(Header::RFC7231, $time);
         $this->setCacheDependency($ro);
     }
 

--- a/src/Header.php
+++ b/src/Header.php
@@ -17,5 +17,12 @@ final class Header
     public const CACHE_CONTROL = 'Cache-Control';
     public const AGE = 'Age';
     public const LAST_MODIFIED = 'Last-Modified';
+
+    /**
+     * RFC 7231 date format for HTTP headers
+     *
+     * @see https://www.rfc-editor.org/rfc/rfc7231#section-7.1.1.1
+     */
+    public const RFC7231 = 'D, d M Y H:i:s \G\M\T';
     public const HTTP_IF_NONE_MATCH = 'HTTP_IF_NONE_MATCH';
 }

--- a/src/MobileEtagSetter.php
+++ b/src/MobileEtagSetter.php
@@ -24,7 +24,7 @@ final class MobileEtagSetter implements EtagSetterInterface
         $ro->headers[Header::ETAG] = (string) crc32($this->getDevice() . serialize($ro->view) . serialize($ro->body));
         // time
         $time ??= time();
-        $ro->headers[Header::LAST_MODIFIED] = gmdate('D, d M Y H:i:s', $time) . ' GMT';
+        $ro->headers[Header::LAST_MODIFIED] = gmdate(Header::RFC7231, $time);
     }
 
     /**


### PR DESCRIPTION
## Summary
- `DateTimeInterface::RFC7231` is deprecated in PHP 8.5 ([php-src#12989](https://github.com/php/php-src/pull/12989))
- Replaced with literal format string `'D, d M Y H:i:s \G\M\T'` in `EtagSetter` and `DevEtagSetter`
- No behavioral change since `gmdate()` always outputs GMT

## Test plan
- [x] `composer test` all tests pass
- [x] `composer cs-fix` no violations