### PR TITLE
Resolve embed dependency before HAL rendering strips Request from body

### DIFF
--- a/src/DevEtagSetter.php
+++ b/src/DevEtagSetter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\QueryRepository;
 
 use BEAR\RepositoryModule\Annotation\HttpCache;
-use BEAR\Resource\Request;
 use BEAR\Resource\ResourceObject;
 use Override;
 
@@ -13,9 +12,15 @@ use function gmdate;
 
 final readonly class DevEtagSetter implements EtagSetterInterface
 {
+    /**
+     * The CacheDependencyInterface argument is retained for backward
+     * compatibility. Dependency resolution is performed by
+     * QueryRepository::put() before parent rendering.
+     */
     public function __construct(
-        private CacheDependencyInterface $cacheDeperency,
+        CacheDependencyInterface $cacheDeperency,
     ) {
+        unset($cacheDeperency);
     }
 
     /**
@@ -30,17 +35,5 @@ final readonly class DevEtagSetter implements EtagSetterInterface
         // Usually, the ETag is a hash of the resource view or body.
         $ro->headers[Header::ETAG] = $uriEtag;
         $ro->headers[Header::LAST_MODIFIED] = gmdate(Header::RFC7231, 0);
-        $this->setCacheDependency($ro);
-    }
-
-    /** @codeCoverageIgnore */
-    private function setCacheDependency(ResourceObject $ro): void
-    {
-        /** @var mixed $body */
-        foreach ((array) $ro->body as $body) {
-            if ($body instanceof Request && isset($body->resourceObject->headers[Header::ETAG])) {
-                $this->cacheDeperency->depends($ro, $body->resourceObject);
-            }
-        }
     }
 }

--- a/src/DevEtagSetter.php
+++ b/src/DevEtagSetter.php
@@ -13,17 +13,6 @@ use function gmdate;
 final readonly class DevEtagSetter implements EtagSetterInterface
 {
     /**
-     * The CacheDependencyInterface argument is retained for backward
-     * compatibility. Dependency resolution is performed by
-     * QueryRepository::put() before parent rendering.
-     */
-    public function __construct(
-        CacheDependencyInterface $cacheDeperency,
-    ) {
-        unset($cacheDeperency);
-    }
-
-    /**
      * {@inheritDoc}
      */
     #[Override]

--- a/src/EtagSetter.php
+++ b/src/EtagSetter.php
@@ -19,17 +19,6 @@ use function time;
 final readonly class EtagSetter implements EtagSetterInterface
 {
     /**
-     * The CacheDependencyInterface argument is retained for backward
-     * compatibility. Dependency resolution is performed by
-     * QueryRepository::put() before parent rendering.
-     */
-    public function __construct(
-        CacheDependencyInterface $cacheDeperency,
-    ) {
-        unset($cacheDeperency);
-    }
-
-    /**
      * {@inheritDoc}
      */
     #[Override]

--- a/src/EtagSetter.php
+++ b/src/EtagSetter.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace BEAR\QueryRepository;
 
 use BEAR\RepositoryModule\Annotation\HttpCache;
-use BEAR\Resource\Request;
 use BEAR\Resource\ResourceObject;
 use Override;
 
@@ -19,9 +18,15 @@ use function time;
 
 final readonly class EtagSetter implements EtagSetterInterface
 {
+    /**
+     * The CacheDependencyInterface argument is retained for backward
+     * compatibility. Dependency resolution is performed by
+     * QueryRepository::put() before parent rendering.
+     */
     public function __construct(
-        private CacheDependencyInterface $cacheDeperency,
+        CacheDependencyInterface $cacheDeperency,
     ) {
+        unset($cacheDeperency);
     }
 
     /**
@@ -38,7 +43,6 @@ final readonly class EtagSetter implements EtagSetterInterface
         $etag =  $this->getEtag($ro, $httpCache);
         $ro->headers[Header::ETAG] = $etag;
         $ro->headers[Header::LAST_MODIFIED] = gmdate(Header::RFC7231, $time);
-        $this->setCacheDependency($ro);
     }
 
     public function getEtagByPartialBody(HttpCache $httpCacche, ResourceObject $ro): string
@@ -71,15 +75,5 @@ final readonly class EtagSetter implements EtagSetterInterface
         $etag = $httpCache instanceof HttpCache && $httpCache->etag ? $this->getEtagByPartialBody($httpCache, $ro) : $this->getEtagByEitireView($ro);
 
         return (string) crc32($ro::class . $etag . (string) $ro->uri);
-    }
-
-    private function setCacheDependency(ResourceObject $ro): void
-    {
-        /** @var mixed $body */
-        foreach ((array) $ro->body as $body) {
-            if ($body instanceof Request && isset($body->resourceObject->headers[Header::ETAG])) {
-                $this->cacheDeperency->depends($ro, $body->resourceObject);
-            }
-        }
     }
 }

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -20,16 +20,13 @@ use function time;
 
 final readonly class QueryRepository implements QueryRepositoryInterface
 {
-    private CacheDependencyInterface $cacheDependency;
-
     public function __construct(
         private RepositoryLoggerInterface $logger,
         private HeaderSetter $headerSetter,
         private ResourceStorageInterface $storage,
         private Expiry $expiry,
-        CacheDependencyInterface|null $cacheDependency = null,
+        private CacheDependencyInterface $cacheDependency,
     ) {
-        $this->cacheDependency = $cacheDependency ?? new CacheDependency(new UriTag());
     }
 
     /**

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -71,7 +71,11 @@ final readonly class QueryRepository implements QueryRepositoryInterface
                 continue;
             }
 
-            // Evaluate the child while HAL still leaves the Request in body.
+            // Materialize the child while HAL still has the Request in body.
+            // For a plain Request this renders the single child; for an
+            // AsyncRequest the first cast drains BEAR\Async\PendingRequests
+            // and runs every queued embed in parallel, with later iterations
+            // hitting the resolved cache.
             (string) $body;
             if (! isset($body->resourceObject->headers[Header::ETAG])) {
                 continue;

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -8,6 +8,7 @@ use BEAR\QueryRepository\Exception\ExpireAtKeyNotExists;
 use BEAR\RepositoryModule\Annotation\Cacheable;
 use BEAR\RepositoryModule\Annotation\HttpCache;
 use BEAR\Resource\AbstractUri;
+use BEAR\Resource\Request;
 use BEAR\Resource\ResourceObject;
 use Override;
 use ReflectionClass;
@@ -19,12 +20,16 @@ use function time;
 
 final readonly class QueryRepository implements QueryRepositoryInterface
 {
+    private CacheDependencyInterface $cacheDependency;
+
     public function __construct(
         private RepositoryLoggerInterface $logger,
         private HeaderSetter $headerSetter,
         private ResourceStorageInterface $storage,
         private Expiry $expiry,
+        CacheDependencyInterface|null $cacheDependency = null,
     ) {
+        $this->cacheDependency = $cacheDependency ?? new CacheDependency(new UriTag());
     }
 
     /**
@@ -35,6 +40,10 @@ final readonly class QueryRepository implements QueryRepositoryInterface
     {
         $this->logger->log('put-query-repository', ['uri' => (string) $ro->uri]);
         $this->storage->deleteEtag($ro->uri);
+        if ($ro->code === 200) {
+            $this->setCacheDependency($ro);
+        }
+
         $ro->toString();
         $cacheable = $this->getCacheableAnnotation($ro);
         $httpCache = $this->getHttpCacheAnnotation($ro);
@@ -51,6 +60,28 @@ final readonly class QueryRepository implements QueryRepositoryInterface
         }
 
         return $this->storage->saveValue($ro, $ttl);
+    }
+
+    private function setCacheDependency(ResourceObject $ro): void
+    {
+        if (isset($ro->headers[Header::SURROGATE_KEY])) {
+            return;
+        }
+
+        /** @var mixed $body */
+        foreach ((array) $ro->body as $body) {
+            if (! ($body instanceof Request)) {
+                continue;
+            }
+
+            // Evaluate the child while HAL still leaves the Request in body.
+            (string) $body;
+            if (! isset($body->resourceObject->headers[Header::ETAG])) {
+                continue;
+            }
+
+            $this->cacheDependency->depends($ro, $body->resourceObject);
+        }
     }
 
     /**

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -72,10 +72,10 @@ final readonly class QueryRepository implements QueryRepositoryInterface
             }
 
             // Materialize the child while HAL still has the Request in body.
-            // For a plain Request this renders the single child; for an
-            // AsyncRequest the first cast drains BEAR\Async\PendingRequests
-            // and runs every queued embed in parallel, with later iterations
-            // hitting the resolved cache.
+            // AbstractRequest::__toString() memoizes the inner result, so
+            // repeated casts here and in the HAL renderer share one
+            // invocation regardless of the request implementation's
+            // execution strategy.
             (string) $body;
             if (! isset($body->resourceObject->headers[Header::ETAG])) {
                 continue;

--- a/src/QueryRepository.php
+++ b/src/QueryRepository.php
@@ -7,8 +7,8 @@ namespace BEAR\QueryRepository;
 use BEAR\QueryRepository\Exception\ExpireAtKeyNotExists;
 use BEAR\RepositoryModule\Annotation\Cacheable;
 use BEAR\RepositoryModule\Annotation\HttpCache;
+use BEAR\Resource\AbstractRequest;
 use BEAR\Resource\AbstractUri;
-use BEAR\Resource\Request;
 use BEAR\Resource\ResourceObject;
 use Override;
 use ReflectionClass;
@@ -67,7 +67,7 @@ final readonly class QueryRepository implements QueryRepositoryInterface
 
         /** @var mixed $body */
         foreach ((array) $ro->body as $body) {
-            if (! ($body instanceof Request)) {
+            if (! ($body instanceof AbstractRequest)) {
                 continue;
             }
 

--- a/tests/CacheDependencyTest.php
+++ b/tests/CacheDependencyTest.php
@@ -129,6 +129,24 @@ class CacheDependencyTest extends TestCase
         $this->assertFalse($this->storage->hasEtag($etagB));
     }
 
+    /**
+     * Non-Cacheable child has no ETag header, so setCacheDependency must
+     * continue past it without registering a (parent, child) dependency. The
+     * parent's cached state still gets a Surrogate-Key (its own URI tag),
+     * but the child's URI tag must NOT appear in it.
+     */
+    public function testNonCacheableChildDoesNotContributeSurrogateKey(): void
+    {
+        $this->resource->get('page://self/dep/parent-of-non-cacheable');
+
+        $parent = $this->repository->get(new Uri('page://self/dep/parent-of-non-cacheable'));
+        $this->assertInstanceOf(ResourceState::class, $parent);
+
+        $childTag = (new UriTag())(new Uri('page://self/dep/non-cacheable-child'));
+        $surrogateKey = $parent->headers[Header::SURROGATE_KEY] ?? '';
+        $this->assertStringNotContainsString($childTag, $surrogateKey);
+    }
+
     public function testHalEmbeddedChildAddsChildSurrogateKeyToParent(): void
     {
         $module = ModuleFactory::getInstance('FakeVendor\HelloWorld');

--- a/tests/CacheDependencyTest.php
+++ b/tests/CacheDependencyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BEAR\QueryRepository;
 
+use BEAR\Resource\Module\HalModule;
 use BEAR\Resource\ResourceInterface;
 use BEAR\Resource\Uri;
 use PHPUnit\Framework\TestCase;
@@ -126,5 +127,22 @@ class CacheDependencyTest extends TestCase
         // ETags should also be invalidated
         $this->assertFalse($this->storage->hasEtag($etagA));
         $this->assertFalse($this->storage->hasEtag($etagB));
+    }
+
+    public function testHalEmbeddedChildAddsChildSurrogateKeyToParent(): void
+    {
+        $module = ModuleFactory::getInstance('FakeVendor\HelloWorld');
+        $module->override(new HalModule());
+        $injector = new Injector(new FakeEtagPoolModule($module), __DIR__ . '/tmp');
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $repository = $injector->getInstance(QueryRepositoryInterface::class);
+
+        $resource->get('page://self/hal/parent-resource');
+
+        $parent = $repository->get(new Uri('page://self/hal/parent-resource'));
+        $this->assertInstanceOf(ResourceState::class, $parent);
+        $childTag = (new UriTag())(new Uri('page://self/hal/child'));
+
+        $this->assertStringContainsString($childTag, $parent->headers[Header::SURROGATE_KEY] ?? '');
     }
 }

--- a/tests/EtagSetterTest.php
+++ b/tests/EtagSetterTest.php
@@ -22,7 +22,7 @@ class EtagSetterTest extends TestCase
 
     public function testStatusNotOk(): void
     {
-        $setEtag = new EtagSetter(new CacheDependency(new UriTag()));
+        $setEtag = new EtagSetter();
         $ro = new Code();
         $ro->code = 500;
         $setEtag($ro);
@@ -33,7 +33,7 @@ class EtagSetterTest extends TestCase
     public function testInvoke(): void
     {
         $ro = $this->resource->get('app://self/user', ['id' => 1]);
-        $setEtag = new EtagSetter(new CacheDependency(new UriTag()));
+        $setEtag = new EtagSetter();
         $time = 0;
         $setEtag($ro, $time);
         $expect = 'Thu, 01 Jan 1970 00:00:00 GMT';

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/NonCacheableChild.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/NonCacheableChild.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\Resource\ResourceObject;
+
+class NonCacheableChild extends ResourceObject
+{
+    public $body = ['non-cacheable-child' => 1];
+
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/ParentOfNonCacheable.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/ParentOfNonCacheable.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class ParentOfNonCacheable extends ResourceObject
+{
+    public $body = ['parent-of-non-cacheable' => 1];
+
+    #[Embed(rel: 'child', src: '/dep/non-cacheable-child')]
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Hal/Child.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Hal/Child.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Hal;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class Child extends ResourceObject
+{
+    public $body = [
+        'child' => 'hal',
+    ];
+
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Hal/ParentResource.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Hal/ParentResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Hal;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class ParentResource extends ResourceObject
+{
+    public $body = [
+        'parent' => 'hal',
+    ];
+
+    #[Embed(rel: 'child', src: '/hal/child')]
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/ResourceRepositoryTest.php
+++ b/tests/ResourceRepositoryTest.php
@@ -70,8 +70,12 @@ class ResourceRepositoryTest extends TestCase
         $this->assertSame($headers['content-type'], $roHeaders['content-type']);
         $this->assertSame($headers['etag'], $roHeaders['etag']);
         $this->assertSame($headers['last-modified'], $roHeaders['last-modified']);
-        $this->assertSame('0', $headers['age']);
+        // Age is `time() - strtotime(Last-Modified)`, so put→get crossing a
+        // second boundary on a slow runner can land on '1'. Either value is
+        // a correct freshly-cached response — what matters is that the
+        // header is present and small.
         $this->assertArrayHasKey('age', $headers);
+        $this->assertContains($headers['age'], ['0', '1']);
         $this->assertSame($state->body, $this->ro->body);
     }
 

--- a/tests/ResourceRepositoryTest.php
+++ b/tests/ResourceRepositoryTest.php
@@ -38,7 +38,7 @@ class ResourceRepositoryTest extends TestCase
         };
         $this->repository = new Repository(
             new RepositoryLogger(),
-            new HeaderSetter(new EtagSetter(new CacheDependency(new UriTag()))),
+            new HeaderSetter(new EtagSetter()),
             new ResourceStorage(
                 new RepositoryLogger(),
                 new NullPurger(),
@@ -49,6 +49,7 @@ class ResourceRepositoryTest extends TestCase
                 $tagAwareAdapterProvider,
             ),
             new Expiry(0, 0, 0),
+            new CacheDependency(new UriTag()),
         );
         $this->ro = new Index();
         $this->ro->uri = new Uri('page://self/user');
@@ -101,7 +102,7 @@ class ResourceRepositoryTest extends TestCase
         };
         $repository = new Repository(
             new RepositoryLogger(),
-            new HeaderSetter(new EtagSetter(new CacheDependency(new UriTag()))),
+            new HeaderSetter(new EtagSetter()),
             new ResourceStorage(
                 new RepositoryLogger(),
                 new NullPurger(),
@@ -112,6 +113,7 @@ class ResourceRepositoryTest extends TestCase
                 $tagAwareAdapterProvider,
             ),
             new Expiry(0, 0, 0),
+            new CacheDependency(new UriTag()),
         );
         $this->assertInstanceOf(Repository::class, $repository);
     }


### PR DESCRIPTION
## Problem

`#[Cacheable]` parent + `#[Embed]` `#[Cacheable]` child under the HAL renderer never gets the child's URI tag merged into the parent's `Surrogate-Key`. A `PUT` on the child therefore does **not** invalidate the parent cache. The miss is silent — no error, no log line — and only affects the HAL representation, which is exactly the recommended representation for BEAR resources.

The JSON renderer path is unaffected because `JsonRenderer` does not mutate `$ro->body`.

## Root cause

`HalRenderer::valuateElements()` (in `bearsunday/BEAR.Resource`) unsets every `AbstractRequest` entry from `$ro->body` during `$ro->toString()` and moves the rendered result under `$ro->body['_embedded']`:

```php
unset($ro->body[$key]);
$view = (string) $embeded;
$ro->body['_embedded'][$key] = json_decode($view, null, 512, JSON_THROW_ON_ERROR);
```

`EtagSetter::setCacheDependency()` ran **after** `toString()` and walked `$ro->body` for `Request` instances — by then every Request had been stripped, so `depends()` was never called and the parent's `Surrogate-Key` never gained the child URI tag.

## Fix

Move the dependency walk into `QueryRepository::put()` and run it **before** `$ro->toString()`, while the original `Request` instances are still in `$ro->body`.

The new walk:

- Bails if the resource already has a manually-set `SURROGATE_KEY` (preserves `CacheDependency::depends()`'s assertion contract).
- Casts each `Request` to string before reading its child ETag so lazy decorators (e.g. `bear/async`'s `AsyncRequest`) flush their batch.

## Constructor changes

- `EtagSetter` / `DevEtagSetter`: drop unused `CacheDependencyInterface` argument.
- `QueryRepository`: receive `CacheDependencyInterface` as a required constructor argument.

## Test

`tests/CacheDependencyTest::testHalEmbeddedChildAddsChildSurrogateKeyToParent` renders a `#[Cacheable]` parent that `#[Embed]`s a `#[Cacheable]` child under `HalModule`, then asserts the parent's stored `Surrogate-Key` contains the child URI tag. Without the fix this assertion fails with an empty `Surrogate-Key`.

## Affected pattern surface

Any HAL+JSON resource using `#[Cacheable]` (or `#[CacheableResponse]`) on a parent with `#[Embed]` children. Reproduced and pinned in bearsunday/MyVendor.Cms `app://self/cache/*` showcase.