### PR TITLE
Deduplicate surrogate keys when concatenating with manually-set header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@
 /vendor-bin/**/vendor
 /.php_cs.cache
 /.phpunit-cache/
+/.phpunit.cache/
 /.dump.rdb

--- a/src/SurrogateKeys.php
+++ b/src/SurrogateKeys.php
@@ -38,14 +38,11 @@ final class SurrogateKeys
 
     public function setSurrogateHeader(ResourceObject $ro): void
     {
-        $key = implode(' ', array_unique($this->surrogateKeys));
-        $wasSetManually = isset($ro->headers[Header::SURROGATE_KEY]);
-        if ($wasSetManually) {
-            $ro->headers[Header::SURROGATE_KEY] .= ' ' . $key;
-
-            return;
+        $keys = $this->surrogateKeys;
+        if (isset($ro->headers[Header::SURROGATE_KEY])) {
+            $keys = array_merge(explode(' ', $ro->headers[Header::SURROGATE_KEY]), $keys);
         }
 
-        $ro->headers[Header::SURROGATE_KEY] = $key;
+        $ro->headers[Header::SURROGATE_KEY] = implode(' ', array_unique($keys));
     }
 }

--- a/tests/SurrogateKeysTest.php
+++ b/tests/SurrogateKeysTest.php
@@ -73,4 +73,23 @@ class SurrogateKeysTest extends TestCase
         $etags->setSurrogateHeader($foo);
         $this->assertSame('_foo_', $foo->headers[Header::SURROGATE_KEY]);
     }
+
+    public function testSetSurrogateHeaderDeduplicatesWithManualKeys(): void
+    {
+        $uri = new Uri('app://self/foo');
+        $etags = new SurrogateKeys($uri);
+        $child = new class extends ResourceObject{
+            /** @var array<string, string> */
+            public $headers = [Header::SURROGATE_KEY => 'shared-tag']; // phpcs:ignore
+        };
+        $child->uri = new Uri('app://self/foo1');
+        $etags->addTag($child);
+        $ro = new class extends ResourceObject{
+            /** @var array<string, string> */
+            public $headers = [Header::SURROGATE_KEY => 'shared-tag _foo_']; // phpcs:ignore
+        };
+        $ro->uri = $uri;
+        $etags->setSurrogateHeader($ro);
+        $this->assertSame('shared-tag _foo_ _foo1_', $ro->headers[Header::SURROGATE_KEY]);
+    }
 }


### PR DESCRIPTION
## Problem

`SurrogateKeys::setSurrogateHeader()` applied `array_unique()` only to the internally generated keys. When the `ResourceObject` already had a manually-set `Surrogate-Key` header, the keys were simply concatenated with `.=`, leaving duplicates between the manual set and the internal set.

This happens when a parent resource and its embedded child share a common tag (e.g. a site-wide purge tag): the child's tag is merged into the internal collection via `addTag()`, then concatenated with the parent's manually-set header, producing duplicates.

The result is functionally correct — Surrogate-Key is an unordered token set and purging is idempotent, so duplicates never cause wrong purges. But it is an inconsistency (internal keys are deduplicated, the concatenation is not), and the bloat is a latent risk on CDNs that cap header length, where truncation could drop tags and cause purge misses. The more embeds, the larger the header.

Fixes #175

## Change

Build the full key set first, then apply `array_unique()` once, so manual and internal keys are deduplicated consistently. The manual-key-first ordering is preserved (existing `testSetSurrogateHeader` expectation is unchanged).

## Also

Add `/.phpunit.cache/` to `.gitignore`. `phpunit.xml.dist` uses `cacheDirectory=".phpunit.cache"`, which did not match the stale `/.phpunit-cache/` (hyphen) entry, so the cache directory was left untracked.

## Checks

- [x] `composer cs-fix`
- [x] PHPStan + Psalm
- [x] `composer test`
