### PR TITLE
Fix multi-embed cache dependency losing all but the last child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fix multi-embed cache dependency: a `#[Cacheable]` resource embedding more than one child kept only the last child's dependency, so purging an earlier child failed to invalidate the parent (stale cache). `CacheDependency::depends()` now accumulates child tags instead of overwriting, and the erroneous assertion that a parent had no prior tags has been removed.
+
 ## [1.16.0] - 2026-05-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.16.1] - 2026-06-01
 
 ### Fixed
 - Fix multi-embed cache dependency: a `#[Cacheable]` resource embedding more than one child kept only the last child's dependency, so purging an earlier child failed to invalidate the parent (stale cache). `CacheDependency::depends()` now accumulates child tags instead of overwriting, and the erroneous assertion that a parent had no prior tags has been removed.

--- a/src/CacheDependency.php
+++ b/src/CacheDependency.php
@@ -7,7 +7,6 @@ namespace BEAR\QueryRepository;
 use BEAR\Resource\ResourceObject;
 use Override;
 
-use function assert;
 use function sprintf;
 
 final readonly class CacheDependency implements CacheDependencyInterface
@@ -20,14 +19,17 @@ final readonly class CacheDependency implements CacheDependencyInterface
     #[Override]
     public function depends(ResourceObject $from, ResourceObject $to): void
     {
-        assert(! isset($from->headers[Header::SURROGATE_KEY]));
-
-        $cacheDependencyTags = ($this->uriTag)($to->uri);
+        $childTags = ($this->uriTag)($to->uri);
         if (isset($to->headers[Header::SURROGATE_KEY])) {
-            $cacheDependencyTags .= sprintf(' %s', $to->headers[Header::SURROGATE_KEY]);
+            $childTags .= sprintf(' %s', $to->headers[Header::SURROGATE_KEY]);
             unset($to->headers[Header::SURROGATE_KEY]);
         }
 
-        $from->headers[Header::SURROGATE_KEY] = $cacheDependencyTags;
+        // Accumulate across every embedded child: a resource that embeds more than one
+        // child must depend on all of them, not only the last. Overwriting here used to
+        // silently drop earlier children's dependencies (stale-cache bug).
+        $from->headers[Header::SURROGATE_KEY] = isset($from->headers[Header::SURROGATE_KEY])
+            ? sprintf('%s %s', $from->headers[Header::SURROGATE_KEY], $childTags)
+            : $childTags;
     }
 }

--- a/tests/ComplexCacheDependencyTest.php
+++ b/tests/ComplexCacheDependencyTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\QueryRepository;
+
+use BEAR\Resource\ResourceInterface;
+use BEAR\Resource\Uri;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+
+/**
+ * Stress test for the cache dependency resolution with a DIAMOND graph.
+ *
+ *            diamond-top
+ *            /         \
+ *     diamond-left   diamond-right
+ *            \         /
+ *           diamond-bottom
+ *
+ * `diamond-top` embeds BOTH `diamond-left` and `diamond-right` (multi-embed);
+ * each arm embeds the shared leaf `diamond-bottom`. This exercises cases the
+ * existing chain / single-embed fixtures never reach:
+ *  - a parent that embeds more than one child (multi-embed accumulation),
+ *  - a leaf reachable through two independent paths,
+ *  - precise (non-over-reaching) invalidation of a single arm.
+ */
+class ComplexCacheDependencyTest extends TestCase
+{
+    private ResourceInterface $resource;
+    private QueryRepositoryInterface $repository;
+
+    protected function setUp(): void
+    {
+        $injector = new Injector(new FakeEtagPoolModule(ModuleFactory::getInstance('FakeVendor\HelloWorld')), __DIR__ . '/tmp');
+        $this->resource = $injector->getInstance(ResourceInterface::class);
+        $this->repository = $injector->getInstance(QueryRepositoryInterface::class);
+
+        parent::setUp();
+    }
+
+    private function isCached(string $name): bool
+    {
+        return $this->repository->get(new Uri('page://self/dep/' . $name)) instanceof ResourceState;
+    }
+
+    public function testDiamondBuildsEveryNode(): void
+    {
+        $this->resource->get('page://self/dep/diamond-top');
+
+        foreach (['diamond-top', 'diamond-left', 'diamond-right', 'diamond-bottom'] as $name) {
+            $this->assertTrue($this->isCached($name), $name . ' should be cached after the build');
+        }
+    }
+
+    public function testMultiEmbedParentDependsOnEveryChild(): void
+    {
+        // Regression: diamond-top embeds BOTH arms. Purging EITHER arm must invalidate top.
+        // Before the fix, the second embed overwrote the first, so one arm's dependency was lost.
+        $this->resource->get('page://self/dep/diamond-top');
+        $this->repository->purge(new Uri('page://self/dep/diamond-left'));
+        $this->assertFalse($this->isCached('diamond-top'), 'top must depend on its LEFT child');
+
+        $this->resource->get('page://self/dep/diamond-top'); // rebuild
+        $this->repository->purge(new Uri('page://self/dep/diamond-right'));
+        $this->assertFalse($this->isCached('diamond-top'), 'top must also depend on its RIGHT child');
+    }
+
+    public function testPurgingSharedLeafCascadesThroughBothPaths(): void
+    {
+        $this->resource->get('page://self/dep/diamond-top');
+
+        // diamond-bottom is embedded via both arms; purging it invalidates every ancestor.
+        $this->repository->purge(new Uri('page://self/dep/diamond-bottom'));
+
+        $this->assertFalse($this->isCached('diamond-top'), 'top reaches bottom via both arms');
+        $this->assertFalse($this->isCached('diamond-left'), 'left embeds bottom');
+        $this->assertFalse($this->isCached('diamond-right'), 'right embeds bottom');
+    }
+
+    public function testPurgingOneArmIsPreciseAndDoesNotOverReach(): void
+    {
+        $this->resource->get('page://self/dep/diamond-top');
+
+        // Purge only the left arm.
+        $this->repository->purge(new Uri('page://self/dep/diamond-left'));
+
+        $this->assertFalse($this->isCached('diamond-top'), 'top embeds left -> invalidated');
+        $this->assertTrue($this->isCached('diamond-right'), 'the right arm is independent of left');
+        $this->assertTrue($this->isCached('diamond-bottom'), 'the shared leaf survives an arm purge');
+    }
+
+    public function testRebuildAfterPurgeRePropagatesDependencies(): void
+    {
+        $this->resource->get('page://self/dep/diamond-top');
+        $this->repository->purge(new Uri('page://self/dep/diamond-bottom'));
+        $this->assertFalse($this->isCached('diamond-top'), 'cascade invalidated top');
+
+        // Rebuild and confirm the dependency graph is restored (not a one-shot).
+        $this->resource->get('page://self/dep/diamond-top');
+        $this->assertTrue($this->isCached('diamond-top'));
+        $this->repository->purge(new Uri('page://self/dep/diamond-bottom'));
+        $this->assertFalse($this->isCached('diamond-top'), 'cascade still works after a rebuild');
+    }
+
+    public function testUnrelatedResourceIsUnaffectedByDiamondPurges(): void
+    {
+        $this->resource->get('page://self/dep/diamond-top');
+        $this->resource->get('page://self/dep/child-c'); // unrelated chain
+
+        $this->repository->purge(new Uri('page://self/dep/diamond-bottom'));
+
+        $this->assertTrue($this->isCached('child-c'), 'an unrelated resource must not be touched');
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondBottom.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondBottom.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class DiamondBottom extends ResourceObject
+{
+    public $body = ['diamond-bottom' => 1];
+
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondLeft.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondLeft.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class DiamondLeft extends ResourceObject
+{
+    public $body = ['diamond-left' => 1];
+
+    #[Embed(rel: 'bottom', src: '/dep/diamond-bottom')]
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondRight.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondRight.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class DiamondRight extends ResourceObject
+{
+    public $body = ['diamond-right' => 1];
+
+    #[Embed(rel: 'bottom', src: '/dep/diamond-bottom')]
+    public function onGet()
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondTop.php
+++ b/tests/Fake/fake-app/src/Resource/Page/Dep/DiamondTop.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FakeVendor\HelloWorld\Resource\Page\Dep;
+
+use BEAR\RepositoryModule\Annotation\Cacheable;
+use BEAR\Resource\Annotation\Embed;
+use BEAR\Resource\ResourceObject;
+
+#[Cacheable]
+class DiamondTop extends ResourceObject
+{
+    public $body = ['diamond-top' => 1];
+
+    #[Embed(rel: 'left', src: '/dep/diamond-left')]
+    #[Embed(rel: 'right', src: '/dep/diamond-right')]
+    public function onGet()
+    {
+        return $this;
+    }
+}


### PR DESCRIPTION
## 概要 / Summary

`#[Cacheable]` なリソースが複数の子リソースを埋め込む場合に、親リソースのキャッシュ依存関係が正しく保持されない不具合を修正します。

This fixes a bug where cache dependencies were not preserved correctly when a `#[Cacheable]` resource embedded multiple child resources.

これまで `CacheDependency::depends()` は、子リソースのタグを追加するたびに親リソースの `Surrogate-Key` ヘッダーを上書きしていました。そのため、複数の子を持つ親リソースでは最後に処理された子の依存関係だけが残り、それ以前の子リソースを purge / refresh しても親リソースが無効化されませんでした。

Previously, `CacheDependency::depends()` overwrote the parent's `Surrogate-Key` header on each child dependency, so only the last child dependency was retained.

## 発生条件 / Condition

この不具合は、キャッシュされる親リソースが複数の cacheable な子リソースを embed している場合に発生します。

This bug occurs when a cached parent resource embeds multiple cacheable child resources.

実装上は、embed された子リソースを materialize した後、その子が `ETag` ヘッダーを持つ場合だけ依存関係を登録します。非 cacheable な embed は `ETag` を持たないため、この依存関係登録の対象外です。

In implementation terms, dependency registration only happens when the embedded child has an `ETag` header. Non-cacheable embedded resources are not part of this dependency graph.

## 影響 / Impact

- 本番環境など assertion が無効な環境では、先に埋め込まれた子リソースを更新しても親のキャッシュが残り、古い内容が配信される可能性がありました。
- With assertions disabled, purging or refreshing an earlier child could leave the parent cache stale.
- 開発・テスト環境など assertion が有効な環境では、2 回目の `depends()` 呼び出しで `AssertionError` が発生し、キャッシュ処理が失敗する可能性がありました。
- With assertions enabled, the second `depends()` call could fail with an `AssertionError`.

## 修正内容 / Fix

- `CacheDependency::depends()` で、親リソースの既存の `Surrogate-Key` に子リソースのタグを蓄積するように変更しました。
- `CacheDependency::depends()` now accumulates child tags into the parent's existing `Surrogate-Key`.
- 「親に既存タグがないこと」を前提にした誤った assertion を削除しました。
- Removed the incorrect assertion that assumed the parent had no existing tags.
- 複数子リソースと共有依存を持つ diamond dependency のテストを追加しました。
- Added a diamond dependency test covering multiple children and a shared dependency.

## テスト / Tests

追加した `ComplexCacheDependencyTest` で以下を確認しています。

`ComplexCacheDependencyTest` verifies:

- `DiamondTop` が `DiamondLeft` / `DiamondRight` / `DiamondBottom` を含む全依存タグを保持すること
- `DiamondTop` retains dependency tags for `DiamondLeft`, `DiamondRight`, and `DiamondBottom`.
- 共有下位リソースである `DiamondBottom` を purge すると、親の `DiamondTop` も正しく無効化されること
- Purging shared `DiamondBottom` correctly invalidates parent `DiamondTop`.
- `DiamondLeft` または `DiamondRight` を個別に purge しても、親の `DiamondTop` が正しく無効化されること
- Purging either `DiamondLeft` or `DiamondRight` also invalidates `DiamondTop`.

AI を活用して、単一 embed の既存 fixture では見落としやすい複雑な条件を洗い出し、複数 child・共有 dependency・個別 purge・rebuild 後の再伝播を検証するテストを追加しました。これにより、今回の修正だけでなく今後の回帰検出の信頼性も高めています。

AI-assisted test exploration was used to add complex dependency scenarios covering multiple children, shared dependencies, selective purges, and dependency propagation after rebuilds. This improves confidence in the fix and future regression detection.

品質チェック結果 / Quality checks:

- 126 tests / 243 assertions
- coding standards
- Psalm
- PHPStan

いずれもエラーなしです。

All checks passed.
