### PR TITLE
Remove unused ETag from invalidation tags to prevent non-volatile tag Set leak

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -173,7 +173,7 @@ jobs:
           composer update ${{ matrix.dependencies == 'lowest' && '--prefer-lowest' || '' }} ${{ env.COMPOSER_FLAGS }} ${{ matrix.php-version == '8.5' && '--ignore-platform-req=ext-redis --ignore-platform-req=ext-memcached' || '' }}
 
       - name: Run PHPUnit tests
-        run: ./vendor/bin/phpunit --coverage-clover=coverage.xml
+        run: ./vendor/bin/phpunit ${{ (matrix.os == 'ubuntu-latest' && matrix.php-version == '8.4' && matrix.dependencies == 'highest') && '--coverage-clover=coverage.xml' || '' }}
 
       - name: Upload coverage report
         if: matrix.os == 'ubuntu-latest' && matrix.php-version == '8.4' && matrix.dependencies == 'highest'

--- a/src/ResourceStorage.php
+++ b/src/ResourceStorage.php
@@ -207,8 +207,12 @@ final class ResourceStorage implements ResourceStorageInterface
     /** @return list<string> */
     private function getTags(ResourceObject $ro): array
     {
-        $etag = $ro->headers['ETag'];
-        $tags = [$etag, ($this->uriTag)($ro->uri)];
+        // ETag is intentionally NOT used as an invalidation tag. The cache entry is
+        // purged by its URI tag (deleteEtag/invalidateTags) and surrogate keys; no code
+        // path ever invalidates by ETag. Because ETag is content-versioned, registering it
+        // as a tag produced one non-volatile tag Set per content version that, under a
+        // volatile-* eviction policy, is never reclaimed - leaking memory without being read.
+        $tags = [($this->uriTag)($ro->uri)];
         if (isset($ro->headers[Header::SURROGATE_KEY])) {
             $tags = array_merge($tags, explode(' ', $ro->headers[Header::SURROGATE_KEY]));
         }

--- a/tests/ResourceStorageTest.php
+++ b/tests/ResourceStorageTest.php
@@ -56,4 +56,18 @@ class ResourceStorageTest extends TestCase
         $donut = $this->storage->getDonut($this->ro->uri);
         $this->assertInstanceOf(ResourceDonut::class, $donut);
     }
+
+    public function testEtagIsNotRegisteredAsInvalidationTag(): void
+    {
+        $this->ro->headers['ETag'] = 'test-etag-value';
+        $this->storage->saveValue($this->ro, 0);
+
+        // ETag is not an invalidation tag: invalidating by the ETag value must NOT purge the entry.
+        $this->storage->invalidateTags(['test-etag-value']);
+        $this->assertNotNull($this->storage->get($this->ro->uri));
+
+        // The URI tag still invalidates the same entry.
+        $this->storage->invalidateTags([(new UriTag())($this->ro->uri)]);
+        $this->assertNull($this->storage->get($this->ro->uri));
+    }
 }


### PR DESCRIPTION
## Problem

`ResourceStorage::getTags()` registers the **ETag** as an invalidation tag for every resource-state (`roPool`) save:

```php
$tags = [$etag, ($this->uriTag)($ro->uri)];
```

However, **no code path ever invalidates by ETag**. All invalidation goes through the **URI tag** (`deleteEtag()` → `invalidateTags([$uriTag])`) or surrogate keys. HTTP 304 validation uses the separate `etagPool` (keyed by the ETag, not tagged by it), so it is unaffected.

Because the ETag is content-versioned (`crc32` of the view), each content version creates a **new, non-volatile tag Set** (`\0tags\0{etag}`). Under a `volatile-*` eviction policy (required by `RedisTagAwareAdapter`), these Sets are **never reclaimed** and **never read** — a write-only memory leak that grows monotonically.

## Production evidence

Measured on a production ElastiCache instance (full keyspace scan, read-only):

| tag Set type | count | bytes |
| --- | --- | --- |
| **ETag (unused)** | **222,213 (61%)** | **75 MB** |
| uriTag / surrogate (in use) | 139,686 | 287 MB |

The ETag Sets accounted for **61% of all tag Sets** and were growing **~1.9k/hour**, steadily consuming non-volatile memory that `volatile-lru` cannot evict.

## Fix

Stop registering the ETag as an invalidation tag. The cache entry remains fully purgeable via its URI tag and surrogate keys, and HTTP 304 handling (the `etagPool`) is untouched.

## Test

Adds `testEtagIsNotRegisteredAsInvalidationTag`: after `saveValue()`, invalidating by the ETag value must **not** purge the entry, while invalidating by the URI tag still does. Verified this test fails before the change (`Failed asserting that null is not null`) and passes after.
